### PR TITLE
PDF Sources Downloader for Fact-Checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,5 @@ concatenated_python_code.py
 # ruff
 .ruff.toml
 
+# storage folder
+storage/

--- a/README.md
+++ b/README.md
@@ -317,31 +317,111 @@ Request access to https://docs.google.com/spreadsheets/d/1R0-q5diheG3zXDBq8V2aoU
 
 ### Download sources
 
-The project includes a source downloader tool to fetch PDFs and other source documents. The tool supports:
+The project includes a source downloader tool to fetch PDFs for fact-checking claims. The tool reads a CSV file and downloads files into organized folders.
 
-1. **Basic Usage**
-   ```bash
-   python -m factchecker.tools.sources_downloader
-   ```
-   This uses default settings:
-   - Source file: `sources/sources.csv`
-   - Output folder: `data/`
-   - URL column: "external_link"
 
-2. **Custom Configuration**
-   ```bash
-   python -m factchecker.tools.sources_downloader \
-     --sourcefile custom_sources.csv \
-     --output_folder custom_folder \
-     --url_column url_field \
-     --rows 1 2 3  # Optional: Download specific rows only
-   ```
 
-3. **Features**
-   - Automatically creates output directory if it doesn't exist
-   - Handles failed downloads gracefully with error messages
-   - Supports CSV files with custom column names
-   - Optional row selection for partial downloads
-   - Progress tracking for batch downloads
+### Download sources
 
-Note: The `/data` folder is specified in the `.gitignore` file, so the downloaded PDFs will not be tracked by Git.
+The project includes a source downloader tool to fetch PDFs and other documents referenced in fact-checking claims. The tool reads a CSV file with metadata and downloads the files into organized folders.
+
+#### 1. **Basic Usage**
+
+```bash
+python -m factchecker.tools.sources_downloader
+```
+
+This uses default settings:
+
+- **Source CSV**: `sources/sources.csv`
+- **Output folder**: `data/sources/`
+- **URL column**: `url`
+- **Filename column**: `output_filename`
+- **Subfolder column**: `output_subfolder`
+
+---
+
+#### 2. **Custom Configuration**
+
+```bash
+python -m factchecker.tools.sources_downloader \
+  --sourcefile path/to/your_sources.csv \
+  --output_folder data/sources \
+  --url_column url \
+  --output_filename_column output_filename \
+  --output_subfolder_column output_subfolder \
+  --row_indices 0 1 2  # Optional: download specific rows only
+```
+
+---
+
+#### 3. **Expected CSV Format**
+
+Your CSV should include at least the following columns:
+
+```csv
+url,title,output_filename,output_subfolder
+https://example.com/doc1.pdf,Example Report,example_report.pdf,ipcc
+https://example.com/doc2.pdf,Another Report,another.pdf,wmo
+```
+
+This will result in files being downloaded to:
+
+```
+data/sources/ipcc/example_report.pdf
+data/sources/wmo/another.pdf
+```
+
+---
+
+#### 4. **Features**
+
+- Automatic creation of output directories and subfolders
+- URL validation before download
+- Graceful handling of timeouts, connection errors, and failed downloads
+- Customizable column names via CLI
+- Optional row filtering by index for partial downloads
+- Logging about each downloaded file
+
+---
+
+#### 5. **Programmatic Usage**
+
+You can also use the `SourcesDownloader` in Python directly:
+
+```python
+from factchecker.tools.sources_downloader import SourcesDownloader
+
+downloader = SourcesDownloader(output_folder="data/sources")
+downloaded_files = downloader.download_pdfs_from_csv(
+    sourcefile="sources/sources.csv",
+    row_indices=None,
+    url_column="url",
+    output_filename_column="output_filename",
+    output_subfolder_column="output_subfolder",
+)
+print(f"Downloaded files: {downloaded_files}")
+```
+
+---
+
+#### 6. **Integration with Indexing**
+
+Each subfolder created via the `output_subfolder` column can be used as an indexable directory:
+
+```python
+import os
+
+main_source_directory = "data/sources"
+index_subolder = "subfolder_1"
+indexer_options_list = [
+    {
+        'source_directory': os.path.join(main_source_directory, index_subfolder),
+        'index_name': "example_index"
+    }
+]
+```
+
+---
+
+**Note**: The `/data` folder is listed in `.gitignore` to prevent large source files from being committed to Git.

--- a/factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback.py
+++ b/factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback.py
@@ -49,7 +49,13 @@ EXPERIMENT_PARAMS = {
 def setup_sources(csv_file: str, main_output_folder: str) -> list[str]:
     """Download the sources for the indices."""
     downloader = SourcesDownloader(main_output_folder=main_output_folder)
-    downloaded_files = downloader.download_from_csv(csv_file, rows=None, url_column="url")
+    downloaded_files = downloader.download_pdfs_from_csv(
+        csv_file, 
+        rows=None,
+        url_column="url",
+        output_filename_column="output_filename",
+        output_subfolder_column="output_subfolder",
+        )
     logging.info(f"Downloaded files: {downloaded_files}")
     return downloaded_files
 
@@ -112,40 +118,40 @@ def main():
         main_output_folder="data/sources"
     )
 
-    # Setup strategy
-    strategy = setup_strategy()
+    # # Setup strategy
+    # strategy = setup_strategy()
 
-    # Load and sample claims ensuring balanced dataset
-    logger.info("Loading and sampling claims...")
-    sampled_claims = sample_climatefeedback_claims(
-        csv_path=EXPERIMENT_PARAMS['dataset_path'],
-        total_samples=EXPERIMENT_PARAMS['total_samples'],
-        correct_ratio=EXPERIMENT_PARAMS['correct_ratio']
-    )
+    # # Load and sample claims ensuring balanced dataset
+    # logger.info("Loading and sampling claims...")
+    # sampled_claims = sample_climatefeedback_claims(
+    #     csv_path=EXPERIMENT_PARAMS['dataset_path'],
+    #     total_samples=EXPERIMENT_PARAMS['total_samples'],
+    #     correct_ratio=EXPERIMENT_PARAMS['correct_ratio']
+    # )
 
-    # Evaluate claims
-    collectors = evaluate_climatefeedback_claims(strategy, sampled_claims)
+    # # Evaluate claims
+    # collectors = evaluate_climatefeedback_claims(strategy, sampled_claims)
 
-    # Create and save results DataFrame
-    logger.info("Creating results DataFrame...")
-    results_df = create_results_dataframe(
-        sampled_claims,
-        collectors,
-        verdict_mapper=map_verdict
-    )
+    # # Create and save results DataFrame
+    # logger.info("Creating results DataFrame...")
+    # results_df = create_results_dataframe(
+    #     sampled_claims,
+    #     collectors,
+    #     verdict_mapper=map_verdict
+    # )
     
-    results_file = save_results(results_df)
-    logger.info(f"Results saved to: {results_file}")
+    # results_file = save_results(results_df)
+    # logger.info(f"Results saved to: {results_file}")
 
-    # Calculate and print metrics
-    logger.info("Calculating classification metrics...")
-    metrics = calculate_classification_metrics(
-        collectors['true_labels'],
-        collectors['predicted_results'],
-        verdict_mapper=map_verdict
-    )
-    logger.info("\nClassification Metrics:")
-    print(metrics)
+    # # Calculate and print metrics
+    # logger.info("Calculating classification metrics...")
+    # metrics = calculate_classification_metrics(
+    #     collectors['true_labels'],
+    #     collectors['predicted_results'],
+    #     verdict_mapper=map_verdict
+    # )
+    # logger.info("\nClassification Metrics:")
+    # print(metrics)
 
 if __name__ == "__main__":
     main()

--- a/factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback.py
+++ b/factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback.py
@@ -46,12 +46,12 @@ EXPERIMENT_PARAMS = {
     'label_options': ['correct', 'incorrect', 'not_enough_information'],
 }
 
-def setup_sources(csv_file: str, main_output_folder: str) -> list[str]:
+def setup_sources(csv_file: str, output_folder: str) -> list[str]:
     """Download the sources for the indices."""
-    downloader = SourcesDownloader(main_output_folder=main_output_folder)
+    downloader = SourcesDownloader(output_folder=output_folder)
     downloaded_files = downloader.download_pdfs_from_csv(
         csv_file, 
-        rows=None,
+        row_indices=None,
         url_column="url",
         output_filename_column="output_filename",
         output_subfolder_column="output_subfolder",
@@ -115,43 +115,43 @@ def main():
     # Download sources
     setup_sources(
         csv_file="factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback_sources.csv",
-        main_output_folder="data/sources"
+        output_folder="data/sources"
     )
 
-    # # Setup strategy
-    # strategy = setup_strategy()
+    # Setup strategy
+    strategy = setup_strategy()
 
-    # # Load and sample claims ensuring balanced dataset
-    # logger.info("Loading and sampling claims...")
-    # sampled_claims = sample_climatefeedback_claims(
-    #     csv_path=EXPERIMENT_PARAMS['dataset_path'],
-    #     total_samples=EXPERIMENT_PARAMS['total_samples'],
-    #     correct_ratio=EXPERIMENT_PARAMS['correct_ratio']
-    # )
+    # Load and sample claims ensuring balanced dataset
+    logger.info("Loading and sampling claims...")
+    sampled_claims = sample_climatefeedback_claims(
+        csv_path=EXPERIMENT_PARAMS['dataset_path'],
+        total_samples=EXPERIMENT_PARAMS['total_samples'],
+        correct_ratio=EXPERIMENT_PARAMS['correct_ratio']
+    )
 
-    # # Evaluate claims
-    # collectors = evaluate_climatefeedback_claims(strategy, sampled_claims)
+    # Evaluate claims
+    collectors = evaluate_climatefeedback_claims(strategy, sampled_claims)
 
-    # # Create and save results DataFrame
-    # logger.info("Creating results DataFrame...")
-    # results_df = create_results_dataframe(
-    #     sampled_claims,
-    #     collectors,
-    #     verdict_mapper=map_verdict
-    # )
+    # Create and save results DataFrame
+    logger.info("Creating results DataFrame...")
+    results_df = create_results_dataframe(
+        sampled_claims,
+        collectors,
+        verdict_mapper=map_verdict
+    )
     
-    # results_file = save_results(results_df)
-    # logger.info(f"Results saved to: {results_file}")
+    results_file = save_results(results_df)
+    logger.info(f"Results saved to: {results_file}")
 
-    # # Calculate and print metrics
-    # logger.info("Calculating classification metrics...")
-    # metrics = calculate_classification_metrics(
-    #     collectors['true_labels'],
-    #     collectors['predicted_results'],
-    #     verdict_mapper=map_verdict
-    # )
-    # logger.info("\nClassification Metrics:")
-    # print(metrics)
+    # Calculate and print metrics
+    logger.info("Calculating classification metrics...")
+    metrics = calculate_classification_metrics(
+        collectors['true_labels'],
+        collectors['predicted_results'],
+        verdict_mapper=map_verdict
+    )
+    logger.info("\nClassification Metrics:")
+    print(metrics)
 
 if __name__ == "__main__":
     main()

--- a/factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback.py
+++ b/factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback.py
@@ -68,18 +68,21 @@ def setup_strategy() -> AdvocateMediatorStrategy:
     Settings.chunk_overlap = EXPERIMENT_PARAMS['chunk_overlap']
     
     main_source_directory = EXPERIMENT_PARAMS['main_source_directory']
-    # Get all subdirectories under the main source directory.
-    sources_subfolders = [
-        d.name for d in Path(main_source_directory).iterdir() if d.is_dir()
-    ]
-    
+
     # Create an indexer for each subfolder in the main sources directory
     indexer_options_list = [
         {
-            'source_directory': os.path.join(main_source_directory, subfolder),
-            'index_name': subfolder
-        }
-        for subfolder in sources_subfolders
+            'source_directory': os.path.join(main_source_directory, "ipcc"),
+            'index_name': "ipcc"
+        },
+        {
+            'source_directory': os.path.join(main_source_directory, "wmo"),
+            'index_name': "wmo"
+        },
+        {
+            'source_directory': os.path.join(main_source_directory, "nipcc"),
+            'index_name': "nipcc"
+        },
     ]
     
     # Create a retriever options list for each indexer.

--- a/factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback_sources.csv
+++ b/factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback_sources.csv
@@ -60,4 +60,8 @@ https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter14.pdf
 https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter15.pdf, IPCC AR6 Working Group III Chapter 15, IPCC_AR6_WGIII_Chapter15.pdf, ipcc
 https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter16.pdf, IPCC AR6 Working Group III Chapter 16, IPCC_AR6_WGIII_Chapter16.pdf, ipcc
 https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter17.pdf, IPCC AR6 Working Group III Chapter 17, IPCC_AR6_WGIII_Chapter17.pdf, ipcc
-
+https://library.wmo.int/viewer/58116/download?file=1301_WMO_Climate_services_Energy_en.pdf&type=pdf&navigator=1, WMO State of Climate Services, WMO_Stage_Climate_Services.pdf, wmo
+https://hadleyserver.metoffice.gov.uk/wmolc/WMO_GADCU_2023-2027.pdf, WMO Global Annual to Decadal Climate Update, WMO_Global_Annual_Decadal_Climate_Update.pdf, wmo
+https://library.wmo.int/viewer/66314/download?file=1321_State_of_the_Climate_in_Asia_2022_en.pdf&type=pdf&navigator=1, WMO State of the Climate in Asia, WMO_State_Climate_Asia.pdf, wmo
+https://library.wmo.int/viewer/66342/download?file=1324_en.pdf&type=pdf&navigator=1, WMO State of the Climate in the South-West Pacific, WMO_State_Climate_South_West_Pacific.pdf, wmo
+https://library.wmo.int/viewer/58070/download?file=1300_State_of_the_Climate_in_Africa_2021_en.pdf&type=pdf&navigator=1, WMO State of the Climate in Africa, WMO_State_Climate_Africa.pdf, wmo

--- a/factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback_sources.csv
+++ b/factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback_sources.csv
@@ -1,69 +1,69 @@
-url, title, output_filename, output_subfolder
-https://www.ipcc.ch/report/ar6/syr/downloads/report/IPCC_AR6_SYR_LongerReport.pdf, IPCC AR6 Longer Report, IPCC_AR6_SYR_LongerReport.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_SPM.pdf, IPCC AR6 Working Group I Summary for Policymakers, IPCC_AR6_WGI_SPM.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_TS.pdf, IPCC AR6 Working Group I Technical Summary, IPCC_AR6_WGI_TS.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter01.pdf, IPCC AR6 Working Group I Chapter 1, IPCC_AR6_WGI_Chapter01.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter02.pdf, IPCC AR6 Working Group I Chapter 2, IPCC_AR6_WGI_Chapter02.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter03.pdf, IPCC AR6 Working Group I Chapter 3, IPCC_AR6_WGI_Chapter03.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter04.pdf, IPCC AR6 Working Group I Chapter 4, IPCC_AR6_WGI_Chapter04.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter05.pdf, IPCC AR6 Working Group I Chapter 5, IPCC_AR6_WGI_Chapter05.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter06.pdf, IPCC AR6 Working Group I Chapter 6, IPCC_AR6_WGI_Chapter06.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter07.pdf, IPCC AR6 Working Group I Chapter 7, IPCC_AR6_WGI_Chapter07.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter08.pdf, IPCC AR6 Working Group I Chapter 8, IPCC_AR6_WGI_Chapter08.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter09.pdf, IPCC AR6 Working Group I Chapter 9, IPCC_AR6_WGI_Chapter09.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter10.pdf, IPCC AR6 Working Group I Chapter 10, IPCC_AR6_WGI_Chapter10.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter11.pdf, IPCC AR6 Working Group I Chapter 11, IPCC_AR6_WGI_Chapter11.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter12.pdf, IPCC AR6 Working Group I Chapter 12, IPCC_AR6_WGI_Chapter12.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_SummaryForPolicymakers.pdf, IPCC AR6 Working Group II Summary for Policymakers, IPCC_AR6_WGII_SPM.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_TechnicalSummary.pdf, IPCC AR6 Working Group II Technical Summary, IPCC_AR6_WGII_TS.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter01.pdf, IPCC AR6 Working Group II Chapter 1, IPCC_AR6_WGII_Chapter01.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter02.pdf, IPCC AR6 Working Group II Chapter 2, IPCC_AR6_WGII_Chapter02.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter03.pdf, IPCC AR6 Working Group II Chapter 3, IPCC_AR6_WGII_Chapter03.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter04.pdf, IPCC AR6 Working Group II Chapter 4, IPCC_AR6_WGII_Chapter04.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter05.pdf, IPCC AR6 Working Group II Chapter 5, IPCC_AR6_WGII_Chapter05.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter06.pdf, IPCC AR6 Working Group II Chapter 6, IPCC_AR6_WGII_Chapter06.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter07.pdf, IPCC AR6 Working Group II Chapter 7, IPCC_AR6_WGII_Chapter07.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter08.pdf, IPCC AR6 Working Group II Chapter 8, IPCC_AR6_WGII_Chapter08.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter09.pdf, IPCC AR6 Working Group II Chapter 9, IPCC_AR6_WGII_Chapter09.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter10.pdf, IPCC AR6 Working Group II Chapter 10, IPCC_AR6_WGII_Chapter10.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter11.pdf, IPCC AR6 Working Group II Chapter 11, IPCC_AR6_WGII_Chapter11.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter12.pdf, IPCC AR6 Working Group II Chapter 12, IPCC_AR6_WGII_Chapter12.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter13.pdf, IPCC AR6 Working Group II Chapter 13, IPCC_AR6_WGII_Chapter13.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter14.pdf, IPCC AR6 Working Group II Chapter 14, IPCC_AR6_WGII_Chapter14.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter15.pdf, IPCC AR6 Working Group II Chapter 15, IPCC_AR6_WGII_Chapter15.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter16.pdf, IPCC AR6 Working Group II Chapter 16, IPCC_AR6_WGII_Chapter16.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter17.pdf, IPCC AR6 Working Group II Chapter 17, IPCC_AR6_WGII_Chapter17.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter18.pdf, IPCC AR6 Working Group II Chapter 18, IPCC_AR6_WGII_Chapter18.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_CCP1.pdf, IPCC AR6 Working Group II Cross-Chapter Paper 1, IPCC_AR6_WGII_CCP1.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_CCP2.pdf, IPCC AR6 Working Group II Cross-Chapter Paper 2, IPCC_AR6_WGII_CCP2.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_CCP3.pdf, IPCC AR6 Working Group II Cross-Chapter Paper 3, IPCC_AR6_WGII_CCP3.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_CCP4.pdf, IPCC AR6 Working Group II Cross-Chapter Paper 4, IPCC_AR6_WGII_CCP4.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_CCP5.pdf, IPCC AR6 Working Group II Cross-Chapter Paper 5, IPCC_AR6_WGII_CCP5.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_CCP6.pdf, IPCC AR6 Working Group II Cross-Chapter Paper 6, IPCC_AR6_WGII_CCP6.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_CCP7.pdf, IPCC AR6 Working Group II Cross-Chapter Paper 7, IPCC_AR6_WGII_CCP7.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_SummaryForPolicymakers.pdf, IPCC AR6 Working Group III Summary for Policymakers, IPCC_AR6_WGIII_SPM.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_TechnicalSummary.pdf, IPCC AR6 Working Group III Technical Summary, IPCC_AR6_WGIII_TS.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter01.pdf, IPCC AR6 Working Group III Chapter 1, IPCC_AR6_WGIII_Chapter01.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter02.pdf, IPCC AR6 Working Group III Chapter 2, IPCC_AR6_WGIII_Chapter02.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter03.pdf, IPCC AR6 Working Group III Chapter 3, IPCC_AR6_WGIII_Chapter03.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter04.pdf, IPCC AR6 Working Group III Chapter 4, IPCC_AR6_WGIII_Chapter04.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter05.pdf, IPCC AR6 Working Group III Chapter 5, IPCC_AR6_WGIII_Chapter05.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter06.pdf, IPCC AR6 Working Group III Chapter 6, IPCC_AR6_WGIII_Chapter06.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter07.pdf, IPCC AR6 Working Group III Chapter 7, IPCC_AR6_WGIII_Chapter07.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter08.pdf, IPCC AR6 Working Group III Chapter 8, IPCC_AR6_WGIII_Chapter08.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter09.pdf, IPCC AR6 Working Group III Chapter 9, IPCC_AR6_WGIII_Chapter09.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter10.pdf, IPCC AR6 Working Group III Chapter 10, IPCC_AR6_WGIII_Chapter10.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter11.pdf, IPCC AR6 Working Group III Chapter 11, IPCC_AR6_WGIII_Chapter11.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter12.pdf, IPCC AR6 Working Group III Chapter 12, IPCC_AR6_WGIII_Chapter12.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter13.pdf, IPCC AR6 Working Group III Chapter 13, IPCC_AR6_WGIII_Chapter13.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter14.pdf, IPCC AR6 Working Group III Chapter 14, IPCC_AR6_WGIII_Chapter14.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter15.pdf, IPCC AR6 Working Group III Chapter 15, IPCC_AR6_WGIII_Chapter15.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter16.pdf, IPCC AR6 Working Group III Chapter 16, IPCC_AR6_WGIII_Chapter16.pdf, ipcc
-https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter17.pdf, IPCC AR6 Working Group III Chapter 17, IPCC_AR6_WGIII_Chapter17.pdf, ipcc
-https://library.wmo.int/viewer/58116/download?file=1301_WMO_Climate_services_Energy_en.pdf&type=pdf&navigator=1, WMO State of Climate Services, WMO_Stage_Climate_Services.pdf, wmo
-https://hadleyserver.metoffice.gov.uk/wmolc/WMO_GADCU_2023-2027.pdf, WMO Global Annual to Decadal Climate Update, WMO_Global_Annual_Decadal_Climate_Update.pdf, wmo
-https://library.wmo.int/viewer/66314/download?file=1321_State_of_the_Climate_in_Asia_2022_en.pdf&type=pdf&navigator=1, WMO State of the Climate in Asia, WMO_State_Climate_Asia.pdf, wmo
-https://library.wmo.int/viewer/66342/download?file=1324_en.pdf&type=pdf&navigator=1, WMO State of the Climate in the South-West Pacific, WMO_State_Climate_South_West_Pacific.pdf, wmo
-https://library.wmo.int/viewer/58070/download?file=1300_State_of_the_Climate_in_Africa_2021_en.pdf&type=pdf&navigator=1, WMO State of the Climate in Africa, WMO_State_Climate_Africa.pdf, wmo
-https://climatechangereconsidered.org/wp-content/uploads/2019/01/CCR-II-Physical-Science-10-17-2013-entire-book.pdf, Climate Change Reconsidered II: Physical Science, NIPCC_Climate_Change_Reconsidered_Physical_Science.pdf, nipcc
-https://climatechangereconsidered.org/wp-content/uploads/2019/01/Full-Book.pdf, Climate Change Reconsidered II: Fossil Fuels, NIPCC_Climate_Change_Reconsidered_Fossil_Fuels.pdf, nipcc
+url,title,output_filename,output_subfolder
+https://www.ipcc.ch/report/ar6/syr/downloads/report/IPCC_AR6_SYR_LongerReport.pdf,IPCC AR6 Longer Report,IPCC_AR6_SYR_LongerReport.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_SPM.pdf,IPCC AR6 Working Group I Summary for Policymakers,IPCC_AR6_WGI_SPM.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_TS.pdf,IPCC AR6 Working Group I Technical Summary,IPCC_AR6_WGI_TS.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter01.pdf,IPCC AR6 Working Group I Chapter 1,IPCC_AR6_WGI_Chapter01.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter02.pdf,IPCC AR6 Working Group I Chapter 2,IPCC_AR6_WGI_Chapter02.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter03.pdf,IPCC AR6 Working Group I Chapter 3,IPCC_AR6_WGI_Chapter03.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter04.pdf,IPCC AR6 Working Group I Chapter 4,IPCC_AR6_WGI_Chapter04.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter05.pdf,IPCC AR6 Working Group I Chapter 5,IPCC_AR6_WGI_Chapter05.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter06.pdf,IPCC AR6 Working Group I Chapter 6,IPCC_AR6_WGI_Chapter06.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter07.pdf,IPCC AR6 Working Group I Chapter 7,IPCC_AR6_WGI_Chapter07.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter08.pdf,IPCC AR6 Working Group I Chapter 8,IPCC_AR6_WGI_Chapter08.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter09.pdf,IPCC AR6 Working Group I Chapter 9,IPCC_AR6_WGI_Chapter09.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter10.pdf,IPCC AR6 Working Group I Chapter 10,IPCC_AR6_WGI_Chapter10.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter11.pdf,IPCC AR6 Working Group I Chapter 11,IPCC_AR6_WGI_Chapter11.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter12.pdf,IPCC AR6 Working Group I Chapter 12,IPCC_AR6_WGI_Chapter12.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_SummaryForPolicymakers.pdf,IPCC AR6 Working Group II Summary for Policymakers,IPCC_AR6_WGII_SPM.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_TechnicalSummary.pdf,IPCC AR6 Working Group II Technical Summary,IPCC_AR6_WGII_TS.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter01.pdf,IPCC AR6 Working Group II Chapter 1,IPCC_AR6_WGII_Chapter01.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter02.pdf,IPCC AR6 Working Group II Chapter 2,IPCC_AR6_WGII_Chapter02.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter03.pdf,IPCC AR6 Working Group II Chapter 3,IPCC_AR6_WGII_Chapter03.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter04.pdf,IPCC AR6 Working Group II Chapter 4,IPCC_AR6_WGII_Chapter04.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter05.pdf,IPCC AR6 Working Group II Chapter 5,IPCC_AR6_WGII_Chapter05.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter06.pdf,IPCC AR6 Working Group II Chapter 6,IPCC_AR6_WGII_Chapter06.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter07.pdf,IPCC AR6 Working Group II Chapter 7,IPCC_AR6_WGII_Chapter07.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter08.pdf,IPCC AR6 Working Group II Chapter 8,IPCC_AR6_WGII_Chapter08.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter09.pdf,IPCC AR6 Working Group II Chapter 9,IPCC_AR6_WGII_Chapter09.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter10.pdf,IPCC AR6 Working Group II Chapter 10,IPCC_AR6_WGII_Chapter10.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter11.pdf,IPCC AR6 Working Group II Chapter 11,IPCC_AR6_WGII_Chapter11.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter12.pdf,IPCC AR6 Working Group II Chapter 12,IPCC_AR6_WGII_Chapter12.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter13.pdf,IPCC AR6 Working Group II Chapter 13,IPCC_AR6_WGII_Chapter13.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter14.pdf,IPCC AR6 Working Group II Chapter 14,IPCC_AR6_WGII_Chapter14.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter15.pdf,IPCC AR6 Working Group II Chapter 15,IPCC_AR6_WGII_Chapter15.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter16.pdf,IPCC AR6 Working Group II Chapter 16,IPCC_AR6_WGII_Chapter16.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter17.pdf,IPCC AR6 Working Group II Chapter 17,IPCC_AR6_WGII_Chapter17.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter18.pdf,IPCC AR6 Working Group II Chapter 18,IPCC_AR6_WGII_Chapter18.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_CCP1.pdf,IPCC AR6 Working Group II Cross-Chapter Paper 1,IPCC_AR6_WGII_CCP1.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_CCP2.pdf,IPCC AR6 Working Group II Cross-Chapter Paper 2,IPCC_AR6_WGII_CCP2.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_CCP3.pdf,IPCC AR6 Working Group II Cross-Chapter Paper 3,IPCC_AR6_WGII_CCP3.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_CCP4.pdf,IPCC AR6 Working Group II Cross-Chapter Paper 4,IPCC_AR6_WGII_CCP4.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_CCP5.pdf,IPCC AR6 Working Group II Cross-Chapter Paper 5,IPCC_AR6_WGII_CCP5.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_CCP6.pdf,IPCC AR6 Working Group II Cross-Chapter Paper 6,IPCC_AR6_WGII_CCP6.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_CCP7.pdf,IPCC AR6 Working Group II Cross-Chapter Paper 7,IPCC_AR6_WGII_CCP7.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_SummaryForPolicymakers.pdf,IPCC AR6 Working Group III Summary for Policymakers,IPCC_AR6_WGIII_SPM.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_TechnicalSummary.pdf,IPCC AR6 Working Group III Technical Summary,IPCC_AR6_WGIII_TS.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter01.pdf,IPCC AR6 Working Group III Chapter 1,IPCC_AR6_WGIII_Chapter01.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter02.pdf,IPCC AR6 Working Group III Chapter 2,IPCC_AR6_WGIII_Chapter02.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter03.pdf,IPCC AR6 Working Group III Chapter 3,IPCC_AR6_WGIII_Chapter03.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter04.pdf,IPCC AR6 Working Group III Chapter 4,IPCC_AR6_WGIII_Chapter04.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter05.pdf,IPCC AR6 Working Group III Chapter 5,IPCC_AR6_WGIII_Chapter05.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter06.pdf,IPCC AR6 Working Group III Chapter 6,IPCC_AR6_WGIII_Chapter06.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter07.pdf,IPCC AR6 Working Group III Chapter 7,IPCC_AR6_WGIII_Chapter07.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter08.pdf,IPCC AR6 Working Group III Chapter 8,IPCC_AR6_WGIII_Chapter08.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter09.pdf,IPCC AR6 Working Group III Chapter 9,IPCC_AR6_WGIII_Chapter09.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter10.pdf,IPCC AR6 Working Group III Chapter 10,IPCC_AR6_WGIII_Chapter10.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter11.pdf,IPCC AR6 Working Group III Chapter 11,IPCC_AR6_WGIII_Chapter11.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter12.pdf,IPCC AR6 Working Group III Chapter 12,IPCC_AR6_WGIII_Chapter12.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter13.pdf,IPCC AR6 Working Group III Chapter 13,IPCC_AR6_WGIII_Chapter13.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter14.pdf,IPCC AR6 Working Group III Chapter 14,IPCC_AR6_WGIII_Chapter14.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter15.pdf,IPCC AR6 Working Group III Chapter 15,IPCC_AR6_WGIII_Chapter15.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter16.pdf,IPCC AR6 Working Group III Chapter 16,IPCC_AR6_WGIII_Chapter16.pdf,ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter17.pdf,IPCC AR6 Working Group III Chapter 17,IPCC_AR6_WGIII_Chapter17.pdf,ipcc
+https://library.wmo.int/viewer/58116/download?file=1301_WMO_Climate_services_Energy_en.pdf&type=pdf&navigator=1,WMO State of Climate Services,WMO_Stage_Climate_Services.pdf,wmo
+https://hadleyserver.metoffice.gov.uk/wmolc/WMO_GADCU_2023-2027.pdf,WMO Global Annual to Decadal Climate Update,WMO_Global_Annual_Decadal_Climate_Update.pdf,wmo
+https://library.wmo.int/viewer/66314/download?file=1321_State_of_the_Climate_in_Asia_2022_en.pdf&type=pdf&navigator=1,WMO State of the Climate in Asia,WMO_State_Climate_Asia.pdf,wmo
+https://library.wmo.int/viewer/66342/download?file=1324_en.pdf&type=pdf&navigator=1,WMO State of the Climate in the South-West Pacific,WMO_State_Climate_South_West_Pacific.pdf,wmo
+https://library.wmo.int/viewer/58070/download?file=1300_State_of_the_Climate_in_Africa_2021_en.pdf&type=pdf&navigator=1,WMO State of the Climate in Africa,WMO_State_Climate_Africa.pdf,wmo
+https://climatechangereconsidered.org/wp-content/uploads/2019/01/CCR-II-Physical-Science-10-17-2013-entire-book.pdf,Climate Change Reconsidered II: Physical Science,NIPCC_Climate_Change_Reconsidered_Physical_Science.pdf,nipcc
+https://climatechangereconsidered.org/wp-content/uploads/2019/01/Full-Book.pdf,Climate Change Reconsidered II: Fossil Fuels,NIPCC_Climate_Change_Reconsidered_Fossil_Fuels.pdf,nipcc

--- a/factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback_sources.csv
+++ b/factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback_sources.csv
@@ -65,3 +65,5 @@ https://hadleyserver.metoffice.gov.uk/wmolc/WMO_GADCU_2023-2027.pdf, WMO Global 
 https://library.wmo.int/viewer/66314/download?file=1321_State_of_the_Climate_in_Asia_2022_en.pdf&type=pdf&navigator=1, WMO State of the Climate in Asia, WMO_State_Climate_Asia.pdf, wmo
 https://library.wmo.int/viewer/66342/download?file=1324_en.pdf&type=pdf&navigator=1, WMO State of the Climate in the South-West Pacific, WMO_State_Climate_South_West_Pacific.pdf, wmo
 https://library.wmo.int/viewer/58070/download?file=1300_State_of_the_Climate_in_Africa_2021_en.pdf&type=pdf&navigator=1, WMO State of the Climate in Africa, WMO_State_Climate_Africa.pdf, wmo
+https://climatechangereconsidered.org/wp-content/uploads/2019/01/CCR-II-Physical-Science-10-17-2013-entire-book.pdf, Climate Change Reconsidered II: Physical Science, NIPCC_Climate_Change_Reconsidered_Physical_Science.pdf, nipcc
+https://climatechangereconsidered.org/wp-content/uploads/2019/01/Full-Book.pdf, Climate Change Reconsidered II: Fossil Fuels, NIPCC_Climate_Change_Reconsidered_Fossil_Fuels.pdf, nipcc

--- a/factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback_sources.csv
+++ b/factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback_sources.csv
@@ -1,0 +1,63 @@
+url, title, output_filename, output_subfolder
+https://www.ipcc.ch/report/ar6/syr/downloads/report/IPCC_AR6_SYR_LongerReport.pdf, IPCC AR6 Longer Report, IPCC_AR6_SYR_LongerReport.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_SPM.pdf, IPCC AR6 Working Group I Summary for Policymakers, IPCC_AR6_WGI_SPM.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_TS.pdf, IPCC AR6 Working Group I Technical Summary, IPCC_AR6_WGI_TS.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter01.pdf, IPCC AR6 Working Group I Chapter 1, IPCC_AR6_WGI_Chapter01.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter02.pdf, IPCC AR6 Working Group I Chapter 2, IPCC_AR6_WGI_Chapter02.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter03.pdf, IPCC AR6 Working Group I Chapter 3, IPCC_AR6_WGI_Chapter03.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter04.pdf, IPCC AR6 Working Group I Chapter 4, IPCC_AR6_WGI_Chapter04.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter05.pdf, IPCC AR6 Working Group I Chapter 5, IPCC_AR6_WGI_Chapter05.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter06.pdf, IPCC AR6 Working Group I Chapter 6, IPCC_AR6_WGI_Chapter06.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter07.pdf, IPCC AR6 Working Group I Chapter 7, IPCC_AR6_WGI_Chapter07.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter08.pdf, IPCC AR6 Working Group I Chapter 8, IPCC_AR6_WGI_Chapter08.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter09.pdf, IPCC AR6 Working Group I Chapter 9, IPCC_AR6_WGI_Chapter09.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter10.pdf, IPCC AR6 Working Group I Chapter 10, IPCC_AR6_WGI_Chapter10.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter11.pdf, IPCC AR6 Working Group I Chapter 11, IPCC_AR6_WGI_Chapter11.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg1/downloads/report/IPCC_AR6_WGI_Chapter12.pdf, IPCC AR6 Working Group I Chapter 12, IPCC_AR6_WGI_Chapter12.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_SummaryForPolicymakers.pdf, IPCC AR6 Working Group II Summary for Policymakers, IPCC_AR6_WGII_SPM.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_TechnicalSummary.pdf, IPCC AR6 Working Group II Technical Summary, IPCC_AR6_WGII_TS.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter01.pdf, IPCC AR6 Working Group II Chapter 1, IPCC_AR6_WGII_Chapter01.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter02.pdf, IPCC AR6 Working Group II Chapter 2, IPCC_AR6_WGII_Chapter02.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter03.pdf, IPCC AR6 Working Group II Chapter 3, IPCC_AR6_WGII_Chapter03.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter04.pdf, IPCC AR6 Working Group II Chapter 4, IPCC_AR6_WGII_Chapter04.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter05.pdf, IPCC AR6 Working Group II Chapter 5, IPCC_AR6_WGII_Chapter05.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter06.pdf, IPCC AR6 Working Group II Chapter 6, IPCC_AR6_WGII_Chapter06.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter07.pdf, IPCC AR6 Working Group II Chapter 7, IPCC_AR6_WGII_Chapter07.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter08.pdf, IPCC AR6 Working Group II Chapter 8, IPCC_AR6_WGII_Chapter08.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter09.pdf, IPCC AR6 Working Group II Chapter 9, IPCC_AR6_WGII_Chapter09.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter10.pdf, IPCC AR6 Working Group II Chapter 10, IPCC_AR6_WGII_Chapter10.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter11.pdf, IPCC AR6 Working Group II Chapter 11, IPCC_AR6_WGII_Chapter11.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter12.pdf, IPCC AR6 Working Group II Chapter 12, IPCC_AR6_WGII_Chapter12.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter13.pdf, IPCC AR6 Working Group II Chapter 13, IPCC_AR6_WGII_Chapter13.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter14.pdf, IPCC AR6 Working Group II Chapter 14, IPCC_AR6_WGII_Chapter14.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter15.pdf, IPCC AR6 Working Group II Chapter 15, IPCC_AR6_WGII_Chapter15.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter16.pdf, IPCC AR6 Working Group II Chapter 16, IPCC_AR6_WGII_Chapter16.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter17.pdf, IPCC AR6 Working Group II Chapter 17, IPCC_AR6_WGII_Chapter17.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_Chapter18.pdf, IPCC AR6 Working Group II Chapter 18, IPCC_AR6_WGII_Chapter18.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_CCP1.pdf, IPCC AR6 Working Group II Cross-Chapter Paper 1, IPCC_AR6_WGII_CCP1.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_CCP2.pdf, IPCC AR6 Working Group II Cross-Chapter Paper 2, IPCC_AR6_WGII_CCP2.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_CCP3.pdf, IPCC AR6 Working Group II Cross-Chapter Paper 3, IPCC_AR6_WGII_CCP3.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_CCP4.pdf, IPCC AR6 Working Group II Cross-Chapter Paper 4, IPCC_AR6_WGII_CCP4.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_CCP5.pdf, IPCC AR6 Working Group II Cross-Chapter Paper 5, IPCC_AR6_WGII_CCP5.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_CCP6.pdf, IPCC AR6 Working Group II Cross-Chapter Paper 6, IPCC_AR6_WGII_CCP6.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg2/downloads/report/IPCC_AR6_WGII_CCP7.pdf, IPCC AR6 Working Group II Cross-Chapter Paper 7, IPCC_AR6_WGII_CCP7.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_SummaryForPolicymakers.pdf, IPCC AR6 Working Group III Summary for Policymakers, IPCC_AR6_WGIII_SPM.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_TechnicalSummary.pdf, IPCC AR6 Working Group III Technical Summary, IPCC_AR6_WGIII_TS.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter01.pdf, IPCC AR6 Working Group III Chapter 1, IPCC_AR6_WGIII_Chapter01.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter02.pdf, IPCC AR6 Working Group III Chapter 2, IPCC_AR6_WGIII_Chapter02.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter03.pdf, IPCC AR6 Working Group III Chapter 3, IPCC_AR6_WGIII_Chapter03.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter04.pdf, IPCC AR6 Working Group III Chapter 4, IPCC_AR6_WGIII_Chapter04.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter05.pdf, IPCC AR6 Working Group III Chapter 5, IPCC_AR6_WGIII_Chapter05.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter06.pdf, IPCC AR6 Working Group III Chapter 6, IPCC_AR6_WGIII_Chapter06.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter07.pdf, IPCC AR6 Working Group III Chapter 7, IPCC_AR6_WGIII_Chapter07.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter08.pdf, IPCC AR6 Working Group III Chapter 8, IPCC_AR6_WGIII_Chapter08.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter09.pdf, IPCC AR6 Working Group III Chapter 9, IPCC_AR6_WGIII_Chapter09.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter10.pdf, IPCC AR6 Working Group III Chapter 10, IPCC_AR6_WGIII_Chapter10.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter11.pdf, IPCC AR6 Working Group III Chapter 11, IPCC_AR6_WGIII_Chapter11.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter12.pdf, IPCC AR6 Working Group III Chapter 12, IPCC_AR6_WGIII_Chapter12.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter13.pdf, IPCC AR6 Working Group III Chapter 13, IPCC_AR6_WGIII_Chapter13.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter14.pdf, IPCC AR6 Working Group III Chapter 14, IPCC_AR6_WGIII_Chapter14.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter15.pdf, IPCC AR6 Working Group III Chapter 15, IPCC_AR6_WGIII_Chapter15.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter16.pdf, IPCC AR6 Working Group III Chapter 16, IPCC_AR6_WGIII_Chapter16.pdf, ipcc
+https://www.ipcc.ch/report/ar6/wg3/downloads/report/IPCC_AR6_WGIII_Chapter17.pdf, IPCC AR6 Working Group III Chapter 17, IPCC_AR6_WGIII_Chapter17.pdf, ipcc
+

--- a/factchecker/tools/sources_downloader.py
+++ b/factchecker/tools/sources_downloader.py
@@ -1,109 +1,150 @@
-"""
-Script for downloading source documents used in fact-checking claims.
-
-This module provides functionality to download source documents (PDFs) that are referenced
-in fact-checking claims. These sources are listed in a CSV file along with their claims
-and are essential for verifying factual accuracy. The module supports both batch downloads
-of all sources and selective downloads of specific entries.
-
-The downloaded documents serve as the knowledge base for the fact-checking system,
-enabling verification of claims against original sources.
-"""
-
 import argparse
 import csv
+import logging
 import os
+
 import requests
 
-def download_pdf(url, output_folder, pdf_title):
+logger = logging.getLogger(__name__)
+
+class SourcesDownloader:
     """
-    Download a source document (PDF) from a given URL and save it to the specified folder.
-    
-    These documents are used as primary sources for fact-checking claims. Each document
-    is saved with a specific title that corresponds to its entry in the claims database.
-    
-    Args:
-        url (str): The URL of the source document to download.
-        output_folder (str): The folder path where the source document should be saved.
-        pdf_title (str): The filename to use for the saved document, preserving the link
-                        to its corresponding claim in the database.
+    Script for downloading source documents used in fact-checking claims.
+
+    This class provides functionality to download source documents (PDFs) that are referenced
+    in fact-checking claims. These sources are listed in a CSV file along with their metadata
+    and are essential for verifying factual accuracy. The class supports both batch downloads
+    of all sources and selective downloads of specific entries.
+
+    The downloaded documents serve as the knowledge base for the fact-checking system,
+    enabling verification of claims against original sources.
+    """
+
+    def __init__(self, main_output_folder: str = "data/sources") -> None:
+        """
+        Initialize the SourcesDownloader with the main output folder.
+
+        Args:
+            main_output_folder (str): The main folder where source documents will be stored.
+                                      If the folder does not exist, it will be created.
+
+        """
+        self.main_output_folder = main_output_folder
+        if not os.path.exists(self.main_output_folder):
+            os.makedirs(self.main_output_folder)
+
+    def download_pdf(self, url: str, output_folder: str, pdf_title: str) -> None:
+        """
+        Download a source document (PDF) from a given URL and save it to the specified folder.
         
-    Returns:
-        None
-    
-    Prints:
-        Success or failure message for the download operation.
-    """
-    response = requests.get(url)
-    if response.status_code == 200:
-        pdf_path = os.path.join(output_folder, pdf_title)
-        with open(pdf_path, 'wb') as f:
-            f.write(response.content)
-        print(f"Downloaded {pdf_title}")
-    else:
-        print(f"Failed to download {pdf_title}")
-
-def download_from_csv(sourcefile, rows, url_column, output_folder):
-    """
-    Download source documents from URLs specified in a claims database CSV file.
-    
-    This function processes a CSV file containing fact-checking claims and their
-    associated source documents. It downloads the source documents that support
-    or are referenced by the claims, maintaining the connection between claims
-    and their supporting evidence.
-    
-    Args:
-        sourcefile (str): Path to the CSV file containing claims and their source URLs.
-        rows (list[int], optional): List of specific claim indices to download sources for.
-                                  If None, downloads sources for all claims.
-        url_column (str): Name of the column containing source document URLs.
-        output_folder (str): Folder path where source documents should be saved.
+        These documents are used as primary sources for fact-checking claims. Each document
+        is saved with a specific title that corresponds to its entry in the claims database.
         
-    Returns:
-        None
+        Args:
+            url (str): The URL of the source document to download.
+            output_folder (str): The folder path where the source document should be saved.
+            pdf_title (str): The filename to use for the saved document.
+
+        Raises:
+            KeyError: If the specified url_column does not exist in the CSV file.
         
-    Raises:
-        KeyError: If the specified url_column does not exist in the CSV file.
-    """
-    with open(sourcefile, 'r') as csvfile:
-        reader = csv.DictReader(csvfile)
-        for i, row in enumerate(reader):
-            if rows and i not in rows:
-                continue
-            try:
-                url = row[url_column]
-                # Use provided PDF title or generate a default one
-                pdf_title = row['pdf_title'] if row['pdf_title'] else f"document_{i}.pdf"
-                download_pdf(url, output_folder, pdf_title)
-            except KeyError:
-                print(f"Column {url_column} does not exist in the CSV file.")
+        Returns:
+            None
 
-def main():
-    """
-    Main function to handle command-line arguments and initiate source document downloads.
-    
-    This script is used to build the knowledge base for fact-checking by downloading
-    all referenced source documents. These documents are then used by the fact-checking
-    system to verify claims against original sources.
-    
-    Command-line Arguments:
-        --sourcefile: Path to the CSV file containing claims and source links (default: 'sources/sources.csv')
-        --rows: Specific claims to download sources for (optional, 0-indexed)
-        --url_column: Name of the column containing source URLs (default: 'external_link')
-        --output_folder: Output folder for downloaded source documents (default: 'data')
-    """
-    parser = argparse.ArgumentParser(description="Download source documents for fact-checking from a CSV file.")
-    parser.add_argument('--sourcefile', type=str, default='sources/sources.csv', help='Path to the CSV file containing the source document links.')
-    parser.add_argument('--rows', type=int, nargs='*', help='Specify which claims to download sources for (0-indexed).')
-    parser.add_argument('--url_column', type=str, default='external_link', help='Specify the column containing source URLs.')
-    parser.add_argument('--output_folder', type=str, default='data', help='Output folder for the downloaded source documents.')
-    args = parser.parse_args()
+        """
+        response = requests.get(url)
+        if response.status_code == 200:
+            pdf_path = os.path.join(output_folder, pdf_title)
+            with open(pdf_path, 'wb') as f:
+                f.write(response.content)
+            logging.info(f"Downloaded {pdf_title} to {output_folder}")
+        else:
+            logging.error(f"Failed to download {pdf_title}")
 
-    # Create output folder if it doesn't exist
-    if not os.path.exists(args.output_folder):
-        os.makedirs(args.output_folder)
+    def download_from_csv(self, sourcefile: str, rows: list[int] | None, url_column: str = "url") -> list[str]:
+        """
+        Download source documents from URLs specified in a claims database CSV file.
+        
+        This function processes a CSV file containing fact-checking claims and their associated
+        source documents. It downloads the source documents that support or are referenced by the claims,
+        maintaining the connection between claims and their supporting evidence.
+        
+        Args:
+            sourcefile (str): Path to the CSV file containing claims and their source URLs.
+            rows (list[int], optional): List of specific claim indices to download sources for.
+                                        If None, downloads sources for all claims.
+            url_column (str): Name of the column containing source document URLs.
 
-    download_from_csv(args.sourcefile, args.rows, args.url_column, args.output_folder)
+        Raises:
+            KeyError: If the specified url_column does not exist in the CSV file.
+        
+        Returns:
+            list[str]: A list of file paths for the downloaded documents.
+
+        """
+        downloaded_files = []
+        with open(sourcefile, 'r') as csvfile:
+            reader = csv.DictReader(csvfile)
+            for i, row in enumerate(reader):
+                if rows and i not in rows:
+                    continue
+                try:
+                    url = row[url_column]
+                    pdf_title = row.get('pdf_title', f"document_{i}.pdf")
+                    # Use the output_folder column from the CSV to determine subfolder;
+                    # default to main_output_folder if not provided.
+                    subfolder = row.get('output_folder', "").strip()
+                    output_folder = os.path.join(self.main_output_folder, subfolder) if subfolder else self.main_output_folder
+                    if not os.path.exists(output_folder):
+                        os.makedirs(output_folder)
+                    self.download_pdf(url, output_folder, pdf_title)
+                    downloaded_files.append(os.path.join(output_folder, pdf_title))
+                except KeyError:
+                    logging.error(f"Column {url_column} does not exist in the CSV file.")
+        return downloaded_files
+
+    @staticmethod
+    def run_cli() -> None:
+        """
+        Main function to handle command-line arguments and initiate source document downloads.
+        
+        This script is used to build the knowledge base for fact-checking by downloading
+        all referenced source documents. These documents are then used by the fact-checking
+        system to verify claims against original sources.
+        
+        Command-line Arguments:
+            --sourcefile: Path to the CSV file containing claims and source links (default: 'sources/sources.csv')
+            --rows: Specific claim indices to download sources for (optional, 0-indexed)
+            --url_column: Name of the column containing source URLs (default: 'external_link')
+            --output_folder: Main output folder for the downloaded source documents (default: 'data')
+        
+        Returns:
+            None
+
+        """
+        parser = argparse.ArgumentParser(
+            description="Download source documents for fact-checking from a CSV file."
+        )
+        parser.add_argument(
+            '--sourcefile', type=str, default='sources/sources.csv',
+            help='Path to the CSV file containing the source document links.'
+        )
+        parser.add_argument(
+            '--rows', type=int, nargs='*',
+            help='Specify which claims to download sources for (0-indexed).'
+        )
+        parser.add_argument(
+            '--url_column', type=str, default='external_link',
+            help='Specify the column containing source URLs.'
+        )
+        parser.add_argument(
+            '--output_folder', type=str, default='data',
+            help='Main output folder for the downloaded source documents.'
+        )
+        args = parser.parse_args()
+
+        downloader = SourcesDownloader(args.output_folder)
+        downloader.download_from_csv(args.sourcefile, args.rows, args.url_column)
 
 if __name__ == "__main__":
-    main()
+    SourcesDownloader.run_cli()

--- a/factchecker/tools/sources_downloader.py
+++ b/factchecker/tools/sources_downloader.py
@@ -2,6 +2,7 @@ import argparse
 import csv
 import logging
 import os
+from urllib.parse import urlparse
 
 import requests
 
@@ -20,20 +21,36 @@ class SourcesDownloader:
     enabling verification of claims against original sources.
     """
 
-    def __init__(self, main_output_folder: str = "data/sources") -> None:
+    def __init__(self, output_folder: str = "data/sources") -> None:
         """
         Initialize the SourcesDownloader with the main output folder.
 
         Args:
-            main_output_folder (str): The main folder where source documents will be stored.
+            output_folder (str): The main folder where source documents will be stored.
                                       If the folder does not exist, it will be created.
 
         """
-        self.main_output_folder = main_output_folder
-        if not os.path.exists(self.main_output_folder):
-            os.makedirs(self.main_output_folder)
+        self.output_folder = output_folder
+        if not os.path.exists(self.output_folder):
+            os.makedirs(self.output_folder)
+    
+    def _is_valid_url(self, url: str) -> bool:
+        """
+        Check if a URL is valid before attempting to download from it.
+        
+        Args:
+            url (str): URL to validate
+            
+        Returns:
+            bool: True if the URL is valid, False otherwise
+        """
+        try:
+            result = urlparse(url)
+            return all([result.scheme, result.netloc])
+        except Exception:
+            return False
 
-    def download_pdf(self, url: str, output_folder: str, output_filename: str) -> None:
+    def download_pdf(self, url: str, output_folder: str, output_filename: str) -> bool:
         """
         Download a source document (PDF) from a given URL and save it to the specified folder.
         
@@ -45,29 +62,49 @@ class SourcesDownloader:
             output_folder (str): The folder path where the source document should be saved.
             output_filename (str): The filename to use for the saved document.
             
-        Raises:
-            KeyError: If the specified url_column does not exist in the CSV file.
-        
         Returns:
-            None
+            bool: True if download was successful, False otherwise
         """
+        # Validate URL before attempting download
+        if not self._is_valid_url(url):
+            logger.error(f"Invalid URL format: {url}")
+            return False
+            
         # Ensure the filename ends with '.pdf'
         if not output_filename.lower().endswith('.pdf'):
             output_filename += '.pdf'
         
-        response = requests.get(url)
-        if response.status_code == 200:
+        try:
+            # Add timeout to prevent hanging on slow servers
+            response = requests.get(url, timeout=30)
+            response.raise_for_status()  # Raise exception for 4XX/5XX responses
+            
             pdf_path = os.path.join(output_folder, output_filename)
             with open(pdf_path, 'wb') as f:
                 f.write(response.content)
-            logging.info(f"Downloaded {output_filename} to {output_folder}")
-        else:
-            logging.error(f"Failed to download {url} to {output_folder}/{output_filename}")
+            logger.info(f"Downloaded {output_filename} to {output_folder}")
+            return True
+            
+        except requests.exceptions.Timeout:
+            logger.error(f"Request timed out for {url}")
+            return False
+        except requests.exceptions.HTTPError as e:
+            logger.error(f"HTTP error occurred for {url}: {e}")
+            return False
+        except requests.exceptions.ConnectionError:
+            logger.error(f"Connection error occurred for {url}")
+            return False
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Error occurred during request for {url}: {e}")
+            return False
+        except IOError as e:
+            logger.error(f"IO error occurred while saving {output_filename}: {e}")
+            return False
 
     def download_pdfs_from_csv(
             self, 
             sourcefile: str, 
-            rows: list[int] | None, 
+            row_indices: list[int] | None, 
             url_column: str = "url",
             output_filename_column: str = "output_filename",
             output_subfolder_column: str = "output_subfolder",
@@ -81,13 +118,14 @@ class SourcesDownloader:
         
         Args:
             sourcefile (str): Path to the CSV file containing claims and their source URLs.
-            rows (list[int], optional): List of specific claim indices to download sources for.
+            row_indices (list[int], optional): List of specific claim indices to download sources for.
                                         If None, downloads sources for all claims.
             url_column (str): Name of the column containing source document URLs.
             output_filename_column (str): Name of the column specifying the filename for the downloaded file
             output_subfolder_column (str): Name of the column specifying the subfolder where to download each file
 
         Raises:
+            FileNotFoundError: If the specified CSV file does not exist.
             KeyError: If the specified url_column does not exist in the CSV file.
         
         Returns:
@@ -95,22 +133,40 @@ class SourcesDownloader:
 
         """
         downloaded_files = []
+        
+        # Check if file exists before attempting to open it
+        if not os.path.isfile(sourcefile):
+            logger.error(f"Source file not found: {sourcefile}")
+            raise FileNotFoundError(f"Source file not found: {sourcefile}")
+        
         with open(sourcefile, 'r') as csvfile:
             reader = csv.DictReader(csvfile, skipinitialspace=True)
+            
+            # Validate that required columns exist
+            if reader.fieldnames and url_column not in reader.fieldnames:
+                logger.error(f"Column {url_column} does not exist in the CSV file.")
+                raise KeyError(f"Column {url_column} does not exist in the CSV file.")
+            
             for i, row in enumerate(reader):
-                if rows and i not in rows:
+                if row_indices and i not in row_indices:
                     continue
-                try:
-                    url = row[url_column]
-                    output_filename = row.get(output_filename_column, f"document_{i}.pdf")
-                    subfolder = row.get(output_subfolder_column, "").strip()
-                    output_folder = os.path.join(self.main_output_folder, subfolder) if subfolder else self.main_output_folder
-                    if not os.path.exists(output_folder):
-                        os.makedirs(output_folder)
-                    self.download_pdf(url, output_folder, output_filename)
+                
+                url = row.get(url_column, "").strip()
+                if not url:
+                    logger.warning(f"Empty URL in row {i}, skipping")
+                    continue
+                    
+                output_filename = row.get(output_filename_column, f"document_{i}.pdf")
+                subfolder = row.get(output_subfolder_column, "").strip()
+                output_folder = os.path.join(self.output_folder, subfolder) if subfolder else self.output_folder
+                
+                if not os.path.exists(output_folder):
+                    os.makedirs(output_folder)
+                
+                success = self.download_pdf(url, output_folder, output_filename)
+                if success:
                     downloaded_files.append(os.path.join(output_folder, output_filename))
-                except KeyError:
-                    logging.error(f"Column {url_column} does not exist in the CSV file.")
+                
         return downloaded_files
 
     @staticmethod
@@ -124,13 +180,15 @@ class SourcesDownloader:
         
         Command-line Arguments:
             --sourcefile: Path to the CSV file containing claims and source links (default: 'sources/sources.csv')
-            --rows: Specific claim indices to download sources for (optional, 0-indexed)
+            --row_indices: Specific claim indices to download sources for (optional, 0-indexed)
             --url_column: Name of the column containing source URLs (default: 'external_link')
+            --output_filename_column: Name of the column specifying filename for downloaded file (default: 'output_filename')
+            --output_subfolder_column: Name of the column specifying subfolder for each file (default: 'output_subfolder')
             --output_folder: Main output folder for the downloaded source documents (default: 'data')
         
         Returns:
             None
-
+            
         """
         parser = argparse.ArgumentParser(
             description="Download source documents for fact-checking from a CSV file."
@@ -140,12 +198,20 @@ class SourcesDownloader:
             help='Path to the CSV file containing the source document links.'
         )
         parser.add_argument(
-            '--rows', type=int, nargs='*',
+            '--row_indices', type=int, nargs='*',
             help='Specify which claims to download sources for (0-indexed).'
         )
         parser.add_argument(
             '--url_column', type=str, default='external_link',
             help='Specify the column containing source URLs.'
+        )
+        parser.add_argument(
+            '--output_filename_column', type=str, default='output_filename',
+            help='Specify the column containing filenames for downloaded files.'
+        )
+        parser.add_argument(
+            '--output_subfolder_column', type=str, default='output_subfolder',
+            help='Specify the column containing subfolders for downloaded files.'
         )
         parser.add_argument(
             '--output_folder', type=str, default='data',
@@ -154,7 +220,17 @@ class SourcesDownloader:
         args = parser.parse_args()
 
         downloader = SourcesDownloader(args.output_folder)
-        downloader.download_pdfs_from_csv(args.sourcefile, args.rows, args.url_column)
+        try:
+            downloader.download_pdfs_from_csv(
+                args.sourcefile, 
+                args.row_indices, 
+                args.url_column,
+                args.output_filename_column,
+                args.output_subfolder_column
+            )
+        except (FileNotFoundError, KeyError) as e:
+            logger.error(f"Error: {e}")
+            exit(1)
 
 if __name__ == "__main__":
     SourcesDownloader.run_cli()

--- a/factchecker/tools/sources_downloader.py
+++ b/factchecker/tools/sources_downloader.py
@@ -103,8 +103,8 @@ class SourcesDownloader:
 
     def download_pdfs_from_csv(
             self, 
-            sourcefile: str, 
-            row_indices: list[int] | None, 
+            sourcefile: str = "sources/sources.csv", 
+            row_indices: list[int] | None = None, 
             url_column: str = "url",
             output_filename_column: str = "output_filename",
             output_subfolder_column: str = "output_subfolder",
@@ -202,7 +202,7 @@ class SourcesDownloader:
             help='Specify which claims to download sources for (0-indexed).'
         )
         parser.add_argument(
-            '--url_column', type=str, default='external_link',
+            '--url_column', type=str, default='url',
             help='Specify the column containing source URLs.'
         )
         parser.add_argument(
@@ -214,7 +214,7 @@ class SourcesDownloader:
             help='Specify the column containing subfolders for downloaded files.'
         )
         parser.add_argument(
-            '--output_folder', type=str, default='data',
+            '--output_folder', type=str, default='data/sources',
             help='Main output folder for the downloaded source documents.'
         )
         args = parser.parse_args()

--- a/tests/tools/test_sources_downloader.py
+++ b/tests/tools/test_sources_downloader.py
@@ -57,11 +57,11 @@ def test_output_folder_exists():
          patch('argparse.ArgumentParser.parse_args', return_value=mock_args), \
          patch('os.path.exists', return_value=True), \
          patch('os.makedirs') as mock_makedirs, \
-         patch('factchecker.tools.sources_downloader.SourcesDownloader.download_from_csv') as mock_download:
+         patch('factchecker.tools.sources_downloader.SourcesDownloader.download_pdfs_from_csv') as mock_download:
             
         SourcesDownloader.run_cli()
         mock_makedirs.assert_not_called()
-        # Since the output folder is passed to the constructor, download_from_csv is called with sourcefile, rows, and url_column.
+        # Since the output folder is passed to the constructor, download_pdfs_from_csv is called with sourcefile, rows, and url_column.
         mock_download.assert_called_once_with('test.csv', None, 'external_link')
 
 
@@ -69,7 +69,7 @@ def test_output_folder_exists():
 def test_cli_arguments():
     testargs = ["prog", "--sourcefile", "test.csv", "--rows", "1", "2", "--url_column", "test_url", "--output_folder", "test_data"]
     with patch('sys.argv', testargs):
-        with patch('factchecker.tools.sources_downloader.SourcesDownloader.download_from_csv') as mock_download:
+        with patch('factchecker.tools.sources_downloader.SourcesDownloader.download_pdfs_from_csv') as mock_download:
             SourcesDownloader.run_cli()
             # Assert that the parsed arguments are passed correctly.
             mock_download.assert_called_once_with('test.csv', [1, 2], 'test_url')


### PR DESCRIPTION
This PR adds the SourcesDownloader class to facilitate downloading and organizing source documents (PDFs) referenced in fact-checking claims.

**Features**

- Downloads PDFs from URLs listed in a CSV file
- Organizes files in configurable folder structure
- Supports selective downloading by row indices
- Robust error handling for network issues
- Configurable via command line arguments