### PR TITLE
Sources downloader: defaults for project CSV, tests, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,12 +348,6 @@ Request access to https://docs.google.com/spreadsheets/d/1R0-q5diheG3zXDBq8V2aoU
 
 ### Download sources
 
-The project includes a source downloader tool to fetch PDFs for fact-checking claims. The tool reads a CSV file and downloads files into organized folders.
-
-
-
-### Download sources
-
 The project includes a source downloader tool to fetch PDFs and other documents referenced in fact-checking claims. The tool reads a CSV file with metadata and downloads the files into organized folders.
 
 #### 1. **Basic Usage**
@@ -362,46 +356,45 @@ The project includes a source downloader tool to fetch PDFs and other documents 
 python -m factchecker.tools.sources_downloader
 ```
 
-This uses default settings:
+This uses default settings that match the project's `sources/sources.csv`:
 
 - **Source CSV**: `sources/sources.csv`
 - **Output folder**: `data/sources/`
-- **URL column**: `url`
-- **Filename column**: `output_filename`
+- **URL column**: `external_link`
+- **Filename column**: `pdf_title`
 - **Subfolder column**: `output_subfolder`
 
 ---
 
 #### 2. **Custom Configuration**
 
+Override defaults only when needed:
+
 ```bash
 python -m factchecker.tools.sources_downloader \
   --sourcefile path/to/your_sources.csv \
   --output_folder data/sources \
-  --url_column url \
-  --output_filename_column output_filename \
-  --output_subfolder_column output_subfolder \
   --row_indices 0 1 2  # Optional: download specific rows only
 ```
+
+Use `--url_column`, `--output_filename_column`, and `--output_subfolder_column` if your CSV uses different column names.
 
 ---
 
 #### 3. **Expected CSV Format**
 
-Your CSV should include at least the following columns:
+The default format matches the project's sources file. Your CSV should include at least:
 
 ```csv
-url,title,output_filename,output_subfolder
-https://example.com/doc1.pdf,Example Report,example_report.pdf,ipcc
-https://example.com/doc2.pdf,Another Report,another.pdf,wmo
+external_link,title,date,pdf_link,pdf_title
+https://example.com/doc1.pdf,Example Report,,,example_report.pdf
+https://example.com/reports/IPCC_AR6.pdf,IPCC Report,,,
 ```
 
-This will result in files being downloaded to:
+- **external_link**: URL of the PDF to download.
+- **pdf_title**: Filename for the downloaded file. If empty, the filename is derived from the URL path.
 
-```
-data/sources/ipcc/example_report.pdf
-data/sources/wmo/another.pdf
-```
+Optional **output_subfolder** column places files in subfolders under the output folder (e.g. `data/sources/ipcc/...`).
 
 ---
 
@@ -418,7 +411,7 @@ data/sources/wmo/another.pdf
 
 #### 5. **Programmatic Usage**
 
-You can also use the `SourcesDownloader` in Python directly:
+You can also use the `SourcesDownloader` in Python directly. Defaults match the project's `sources/sources.csv`:
 
 ```python
 from factchecker.tools.sources_downloader import SourcesDownloader
@@ -426,13 +419,11 @@ from factchecker.tools.sources_downloader import SourcesDownloader
 downloader = SourcesDownloader(output_folder="data/sources")
 downloaded_files = downloader.download_pdfs_from_csv(
     sourcefile="sources/sources.csv",
-    row_indices=None,
-    url_column="url",
-    output_filename_column="output_filename",
-    output_subfolder_column="output_subfolder",
 )
 print(f"Downloaded files: {downloaded_files}")
 ```
+
+Pass `url_column`, `output_filename_column`, and `output_subfolder_column` when using a different CSV format.
 
 ---
 

--- a/factchecker/tools/sources_downloader.py
+++ b/factchecker/tools/sources_downloader.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import csv
 import logging
@@ -105,8 +107,8 @@ class SourcesDownloader:
             self, 
             sourcefile: str = "sources/sources.csv", 
             row_indices: list[int] | None = None, 
-            url_column: str = "url",
-            output_filename_column: str = "output_filename",
+            url_column: str = "external_link",
+            output_filename_column: str = "pdf_title",
             output_subfolder_column: str = "output_subfolder",
         ) -> list[str]:
         """
@@ -156,7 +158,11 @@ class SourcesDownloader:
                     logger.warning(f"Empty URL in row {i}, skipping")
                     continue
                     
-                output_filename = row.get(output_filename_column, f"document_{i}.pdf")
+                output_filename = row.get(output_filename_column, "").strip()
+                if not output_filename:
+                    # Derive filename from URL path if possible, otherwise use fallback
+                    url_path = urlparse(url).path
+                    output_filename = os.path.basename(url_path) or f"document_{i}.pdf"
                 subfolder = row.get(output_subfolder_column, "").strip()
                 output_folder = os.path.join(self.output_folder, subfolder) if subfolder else self.output_folder
                 
@@ -182,7 +188,7 @@ class SourcesDownloader:
             --sourcefile: Path to the CSV file containing claims and source links (default: 'sources/sources.csv')
             --row_indices: Specific claim indices to download sources for (optional, 0-indexed)
             --url_column: Name of the column containing source URLs (default: 'external_link')
-            --output_filename_column: Name of the column specifying filename for downloaded file (default: 'output_filename')
+            --output_filename_column: Name of the column specifying filename for downloaded file (default: 'pdf_title')
             --output_subfolder_column: Name of the column specifying subfolder for each file (default: 'output_subfolder')
             --output_folder: Main output folder for the downloaded source documents (default: 'data')
         
@@ -202,11 +208,11 @@ class SourcesDownloader:
             help='Specify which claims to download sources for (0-indexed).'
         )
         parser.add_argument(
-            '--url_column', type=str, default='url',
+            '--url_column', type=str, default='external_link',
             help='Specify the column containing source URLs.'
         )
         parser.add_argument(
-            '--output_filename_column', type=str, default='output_filename',
+            '--output_filename_column', type=str, default='pdf_title',
             help='Specify the column containing filenames for downloaded files.'
         )
         parser.add_argument(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,9 +89,15 @@ def mock_openai_env(monkeypatch):
         def get_text_embedding(self, text):
             return [0.0] * 384
 
-    # Apply mocks
-    monkeypatch.setattr("llama_index.llms.openai.OpenAI", MockOpenAI)
-    monkeypatch.setattr("llama_index.embeddings.openai.OpenAIEmbedding", MockOpenAIEmbedding)
+    # Apply mocks only when llama_index is already loaded (do not import it here to avoid
+    # pulling in numpy/llama_index in tool-only test runs and potential segfaults)
+    if "llama_index" not in sys.modules:
+        return
+    try:
+        monkeypatch.setattr("llama_index.llms.openai.OpenAI", MockOpenAI)
+        monkeypatch.setattr("llama_index.embeddings.openai.OpenAIEmbedding", MockOpenAIEmbedding)
+    except ModuleNotFoundError:
+        pass
 
 @pytest.fixture(autouse=True)
 def setup_test_env():

--- a/tests/tools/test_sources_downloader.py
+++ b/tests/tools/test_sources_downloader.py
@@ -1,10 +1,34 @@
+import importlib.util
 import logging
 import os
+import shutil
+import sys
+import tempfile
+import types
 from unittest.mock import Mock, mock_open, patch
 
 import requests
 
-from factchecker.tools.sources_downloader import SourcesDownloader
+# Import SourcesDownloader without loading factchecker package (avoids openai/llama_index/numpy)
+# Prefer loading by path so tests run in minimal envs and avoid venv numpy segfaults on some systems.
+_test_dir = os.path.dirname(os.path.abspath(__file__))
+_project_root = os.path.dirname(os.path.dirname(_test_dir))
+_module_path = os.path.join(_project_root, "factchecker", "tools", "sources_downloader.py")
+if os.path.isfile(_module_path):
+    for _pkg in ("factchecker", "factchecker.tools"):
+        if _pkg not in sys.modules:
+            sys.modules[_pkg] = types.ModuleType(_pkg)
+    _spec = importlib.util.spec_from_file_location(
+        "factchecker.tools.sources_downloader", _module_path
+    )
+    _mod = importlib.util.module_from_spec(_spec)
+    sys.modules["factchecker.tools.sources_downloader"] = _mod
+    _spec.loader.exec_module(_mod)
+    sys.modules["factchecker"].tools = sys.modules["factchecker.tools"]
+    sys.modules["factchecker.tools"].sources_downloader = _mod
+    SourcesDownloader = _mod.SourcesDownloader
+else:
+    from factchecker.tools.sources_downloader import SourcesDownloader
 
 
 # Test for download_pdf function of Sources Downloader
@@ -50,6 +74,64 @@ def test_output_folder_creation():
         SourcesDownloader.run_cli()
         mock_makedirs.assert_called_once_with('test_data')
 
+def test_download_pdfs_from_csv_with_project_format():
+    """With project CSV format (external_link, pdf_title), defaults work without overrides."""
+    csv_content = "external_link,title,pdf_title\nhttps://example.com/doc.pdf,My Doc,mydoc.pdf\n"
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
+        f.write(csv_content)
+        csv_path = f.name
+    try:
+        out_dir = tempfile.mkdtemp()
+        try:
+            downloader = SourcesDownloader(out_dir)
+            with patch('factchecker.tools.sources_downloader.requests.get') as mock_get:
+                mock_get.return_value.status_code = 200
+                mock_get.return_value.content = b'pdf'
+                mock_get.return_value.raise_for_status = Mock()
+                downloader.download_pdfs_from_csv(csv_path)
+                mock_get.assert_called_once_with('https://example.com/doc.pdf', timeout=30)
+                assert os.path.isfile(os.path.join(out_dir, 'mydoc.pdf'))
+        finally:
+            shutil.rmtree(out_dir, ignore_errors=True)
+    finally:
+        os.unlink(csv_path)
+
+
+def test_empty_pdf_title_derives_from_url():
+    """When pdf_title is empty, filename is derived from URL path."""
+    csv_content = "external_link,title,pdf_title\nhttps://example.com/reports/IPCC_AR6_SYR_LongerReport.pdf,IPCC,\n"
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
+        f.write(csv_content)
+        csv_path = f.name
+    try:
+        out_dir = tempfile.mkdtemp()
+        try:
+            downloader = SourcesDownloader(out_dir)
+            with patch('factchecker.tools.sources_downloader.requests.get') as mock_get:
+                mock_get.return_value.status_code = 200
+                mock_get.return_value.content = b'pdf'
+                mock_get.return_value.raise_for_status = Mock()
+                downloader.download_pdfs_from_csv(csv_path)
+                expected_path = os.path.join(out_dir, 'IPCC_AR6_SYR_LongerReport.pdf')
+                assert os.path.isfile(expected_path)
+        finally:
+            shutil.rmtree(out_dir, ignore_errors=True)
+    finally:
+        os.unlink(csv_path)
+
+
+def test_cli_defaults_match_project_csv():
+    """CLI with no column flags passes external_link and pdf_title as defaults."""
+    with patch('factchecker.tools.sources_downloader.SourcesDownloader.download_pdfs_from_csv') as mock_download:
+        with patch('sys.argv', ['prog']):
+            SourcesDownloader.run_cli()
+        mock_download.assert_called_once()
+        call_kw = mock_download.call_args
+        assert call_kw[0][2] == 'external_link'
+        assert call_kw[0][3] == 'pdf_title'
+        assert call_kw[0][4] == 'output_subfolder'
+
+
 def test_output_folder_exists():
     """Test that existing output folders are handled correctly"""
     mock_args = Mock(
@@ -57,7 +139,7 @@ def test_output_folder_exists():
         output_folder='test_data',
         row_indices=None,
         url_column='external_link',
-        output_filename_column='output_filename',
+        output_filename_column='pdf_title',
         output_subfolder_column='output_subfolder'
     )
     
@@ -71,7 +153,7 @@ def test_output_folder_exists():
         SourcesDownloader.run_cli()
         mock_makedirs.assert_not_called()
         mock_download.assert_called_once_with(
-            'test.csv', None, 'external_link', 'output_filename', 'output_subfolder'
+            'test.csv', None, 'external_link', 'pdf_title', 'output_subfolder'
         )
 
 
@@ -81,5 +163,5 @@ def test_cli_arguments():
     with patch('sys.argv', testargs):
         with patch('factchecker.tools.sources_downloader.SourcesDownloader.download_pdfs_from_csv') as mock_download:
             SourcesDownloader.run_cli()
-            # The row_indices parameter should now be parsed as [1, 2]
-            mock_download.assert_called_once_with('test.csv', [1, 2], 'test_url', 'output_filename', 'output_subfolder')
+            # The row_indices parameter should now be parsed as [1, 2]; output_filename_column keeps default pdf_title
+            mock_download.assert_called_once_with('test.csv', [1, 2], 'test_url', 'pdf_title', 'output_subfolder')


### PR DESCRIPTION
- Default url_column to external_link, output_filename_column to pdf_title so 'python -m factchecker.tools.sources_downloader' works with sources/sources.csv without extra flags.
- Derive filename from URL when pdf_title empty.
- Add tests (project format, empty pdf_title fallback, CLI defaults).
- Update README: defaults, CSV format, remove duplicate section.
- Conftest: skip llama_index mocks when not loaded (tools-only test runs).

Refs #97