### PR TITLE
42 ollama batch embeddings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,8 +26,9 @@ HUGGINGFACE_EMBEDDING_MODEL="BAAI/bge-small-en-v1.5"
 # Optional: Set HUGGINGFACE_EMBEDDING_DEVICE="cuda" for GPU usage
 
 # Ollama Embedding Settings
-# OLLAMA_MODEL and OLLAMA_API_BASE_URL are shared with LLM settings above
-# Default embedding model is "nomic-embed-text" if not specified
+# OLLAMA_EMBEDDING_MODEL: embedding model (e.g. "jina/jina-embeddings-v2-base-de", "nomic-embed-text")
+# OLLAMA_MODEL: used for LLM; also fallback for embeddings if OLLAMA_EMBEDDING_MODEL not set
+# OLLAMA_API_BASE_URL: shared with LLM (default: "http://localhost:11434")
 
 # Semantic Scholar Knowledge Graph API Key
 SEMANTIC_SCHOLAR_KG_API_KEY="your-key-here"

--- a/.env.example
+++ b/.env.example
@@ -25,8 +25,8 @@ HUGGINGFACE_EMBEDDING_MODEL="BAAI/bge-small-en-v1.5"
 # Optional: Set CUDA_VISIBLE_DEVICES for GPU selection
 # Optional: Set HUGGINGFACE_EMBEDDING_DEVICE="cuda" for GPU usage
 
-# Ollama Embedding Settings
-# OLLAMA_EMBEDDING_MODEL: embedding model (e.g. "jina/jina-embeddings-v2-base-de", "nomic-embed-text")
+# Ollama Embedding Settings (required when EMBEDDING_TYPE=ollama)
+OLLAMA_EMBEDDING_MODEL="nomic-embed-text"
 # OLLAMA_MODEL: used for LLM; also fallback for embeddings if OLLAMA_EMBEDDING_MODEL not set
 # OLLAMA_API_BASE_URL: shared with LLM (default: "http://localhost:11434")
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,21 @@ There is a detailled explanation on sources below
 
 3. Run an example
 
-We recommend running the Advocate Mediator example, to test if you set up everything correctly:
+We recommend running the Advocate Mediator example, to test if you set up everything correctly.
 
+**Option A — Run as a module** (all options are set inside the experiment file and via `.env`):
 
-```
+```bash
 python -m factchecker.experiments.advocate_mediator_climatefeedback.advocate_mediator_climatefeedback
 ```
+
+**Option B — Run via script** (same module; script creates Python 3.12 venv and uses `.env`):
+
+```bash
+./run_with_venv.sh
+```
+
+See "Running Experiments" below for both entry points in detail.
 
 
 
@@ -221,7 +230,42 @@ Additional utilities handle common operations like data processing, API interact
 
 ## Running Experiments
 
-The project includes several experiment scripts to evaluate different fact-checking approaches:
+The project includes several experiment scripts to evaluate different fact-checking approaches.
+
+### Advocate-Mediator (Climate Feedback): two ways to run
+
+You can run the advocate-mediator Climate Feedback experiment in either of these ways:
+
+**1. As a module** — Options are set in the experiment file `factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback.py`. LLM and embeddings are controlled via `.env` (e.g. `LLM_TYPE=ollama`, `EMBEDDING_TYPE=ollama`, `OLLAMA_EMBEDDING_MODEL`).
+
+   ```bash
+   python -m factchecker.experiments.advocate_mediator_climatefeedback.advocate_mediator_climatefeedback
+   ```
+
+**2. Via the venv script** — Same module; the script ensures a Python 3.12 venv and loads `.env`:
+
+   ```bash
+   ./run_with_venv.sh
+   ```
+
+---
+
+### Working with limited sources
+
+The experiment downloads PDFs from a CSV by default. To run quickly or with less data:
+
+- **Limit downloads:** In `advocate_mediator_climatefeedback.py`, set `sources_max_sources`: `1` (or another number) in `EXPERIMENT_PARAMS`. Only that many PDFs are downloaded; the indexer loads only those files, not the whole directory.
+- **Use a folder of your own PDFs (no download):** Put your PDF(s) in a folder (e.g. `data/sources/ipcc/`). In `main()`, comment out the download step and build a list of paths to pass in:
+  ```python
+  # downloaded_files = setup_sources(params=params)
+  import pathlib
+  folder = pathlib.Path("data/sources/ipcc")  # or your path
+  downloaded_files = [str(p) for p in folder.glob("*.pdf")]
+  strategy = setup_strategy(params=params, downloaded_files=downloaded_files)
+  ```
+  The indexer will load only those files. Use this when you already have sources and want to skip the downloader.
+
+---
 
 1. Climate Feedback Advocate-Mediator Experiment:
    ```bash

--- a/README.md
+++ b/README.md
@@ -158,18 +158,20 @@ The project uses LlamaIndex's embedding interface through the `factchecker/core/
    - Uses `llama_index.embeddings.huggingface.HuggingFaceEmbedding`
 
 3. **Ollama Embeddings**
-   - Set `EMBEDDING_TYPE=ollama` in `.env`
-   - Required settings:
-     - `OLLAMA_MODEL`: Model to use (default: "nomic-embed-text")
+   - Set `EMBEDDING_TYPE=ollama` in `.env` (or pass `provider="ollama"`)
+   - Model selection (embedding model is separate from LLM):
+     - `OLLAMA_EMBEDDING_MODEL`: Embedding model (e.g. "jina/jina-embeddings-v2-base-de", "nomic-embed-text")
+     - `OLLAMA_MODEL`: Fallback if OLLAMA_EMBEDDING_MODEL not set (default: "nomic-embed-text")
    - Optional settings:
      - `OLLAMA_API_BASE_URL`: Custom API endpoint (default: "http://localhost:11434")
+     - `embed_batch_size`: Texts per request (default from LlamaIndex, typically 10)
    - Additional kwargs support:
      - `request_timeout`: Specific request timeout
    - Features:
-     - Local execution
-     - Integration with Ollama's model ecosystem
+     - Batch API: multiple texts per request (faster than one-by-one)
+     - Local or remote Ollama
      - No API key required
-   - Uses `llama_index.embeddings.ollama.OllamaEmbedding`
+   - Uses `factchecker.core.ollama_batch_embedding.BatchedOllamaEmbedding`
 
 Example usage:
 ```python
@@ -194,11 +196,12 @@ embeddings = load_embedding_model(
     normalize_embeddings=True
 )
 
-# Ollama with custom settings
+# Ollama with custom settings (batch embeddings)
 embeddings = load_embedding_model(
     embedding_type="ollama",
     model_name="nomic-embed-text",
-    base_url="http://custom-server:11434",
+    api_base="http://custom-server:11434",
+    embed_batch_size=32,
     request_timeout=60
 )
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ We recommend running the Advocate Mediator example, to test if you set up everyt
 python -m factchecker.experiments.advocate_mediator_climatefeedback.advocate_mediator_climatefeedback
 ```
 
-**Option B — Run via script** (same module; script creates Python 3.12 venv and uses `.env`):
+**Option B — Run via script** (same module; script creates a venv with Python 3.12 or 3.10 and uses `.env`):
 
 ```bash
 ./run_with_venv.sh
@@ -242,7 +242,7 @@ You can run the advocate-mediator Climate Feedback experiment in either of these
    python -m factchecker.experiments.advocate_mediator_climatefeedback.advocate_mediator_climatefeedback
    ```
 
-**2. Via the venv script** — Same module; the script ensures a Python 3.12 venv and loads `.env`:
+**2. Via the venv script** — Same module; the script ensures a venv (Python 3.12 or 3.10) and loads `.env`:
 
    ```bash
    ./run_with_venv.sh
@@ -250,11 +250,11 @@ You can run the advocate-mediator Climate Feedback experiment in either of these
 
 ---
 
-### Working with limited sources
+### Running with few claims or limited sources
 
-The experiment downloads PDFs from a CSV by default. To run quickly or with less data:
-
+- **Few claims:** When using the experiment runner script, you can limit how many claims are evaluated with `--samples N` (e.g. `--samples 1`). Example: `python run_experiments.py --samples 1 --sources-limit 1` runs a single claim with a single source for quick checks.
 - **Limit downloads:** In `advocate_mediator_climatefeedback.py`, set `sources_max_sources`: `1` (or another number) in `EXPERIMENT_PARAMS`. Only that many PDFs are downloaded; the indexer loads only those files, not the whole directory.
+- **Persistent index:** The vector index can be saved and reloaded (e.g. via `index_path` / load when present, save after build) so repeated runs with the same sources skip re-indexing.
 - **Use a folder of your own PDFs (no download):** Put your PDF(s) in a folder (e.g. `data/sources/ipcc/`). In `main()`, comment out the download step and build a list of paths to pass in:
   ```python
   # downloaded_files = setup_sources(params=params)

--- a/factchecker/core/embeddings.py
+++ b/factchecker/core/embeddings.py
@@ -4,6 +4,8 @@ from llama_index.embeddings.huggingface import HuggingFaceEmbedding
 from llama_index.embeddings.ollama import OllamaEmbedding
 from llama_index.embeddings.openai import OpenAIEmbedding
 
+from factchecker.core.ollama_batch_embedding import BatchedOllamaEmbedding
+
 
 def load_embedding_model(
     embedding_type=None,
@@ -77,7 +79,7 @@ def load_embedding_model(
         model_name = model_name or os.getenv("OLLAMA_MODEL", "nomic-embed-text")
         api_base = api_base or os.getenv("OLLAMA_API_BASE_URL", "http://localhost:11434")
         
-        return OllamaEmbedding(
+        return BatchedOllamaEmbedding(
             model_name=model_name,
             base_url=api_base,
             **kwargs

--- a/factchecker/core/embeddings.py
+++ b/factchecker/core/embeddings.py
@@ -27,7 +27,7 @@ def load_embedding_model(
         model_name (str, optional): Name of the model to use. Defaults vary by embedding type:
             - OpenAI: env var OPENAI_EMBEDDING_MODEL or 'text-embedding-ada-002'
             - HuggingFace: env var HUGGINGFACE_EMBEDDING_MODEL or 'BAAI/bge-small-en-v1.5'
-            - Ollama: env var OLLAMA_MODEL or 'nomic-embed-text'
+            - Ollama: env var OLLAMA_EMBEDDING_MODEL, then OLLAMA_MODEL, or 'nomic-embed-text'
         api_key (str, optional): API key for OpenAI. Defaults to env var OPENAI_API_KEY.
         api_base (str, optional): Base API URL. Defaults vary by embedding type:
             - OpenAI: env var OPENAI_API_BASE
@@ -47,7 +47,8 @@ def load_embedding_model(
         OPENAI_API_KEY: API key for OpenAI
         OPENAI_API_BASE: Base URL for OpenAI API
         HUGGINGFACE_EMBEDDING_MODEL: Model name for HuggingFace embeddings
-        OLLAMA_MODEL: Model name for Ollama embeddings
+        OLLAMA_EMBEDDING_MODEL: Model name for Ollama embeddings (overrides OLLAMA_MODEL for embeddings)
+        OLLAMA_MODEL: Model name for Ollama (used for embeddings if OLLAMA_EMBEDDING_MODEL not set)
         OLLAMA_API_BASE_URL: Base URL for Ollama API
     """
     embedding_type = (
@@ -80,7 +81,11 @@ def load_embedding_model(
         )
         
     elif embedding_type == "ollama":
-        model_name = model_name or os.getenv("OLLAMA_MODEL", "nomic-embed-text")
+        model_name = (
+            model_name
+            or os.getenv("OLLAMA_EMBEDDING_MODEL")
+            or os.getenv("OLLAMA_MODEL", "nomic-embed-text")
+        )
         api_base = api_base or os.getenv("OLLAMA_API_BASE_URL", "http://localhost:11434")
         
         return BatchedOllamaEmbedding(

--- a/factchecker/core/embeddings.py
+++ b/factchecker/core/embeddings.py
@@ -23,7 +23,7 @@ def load_embedding_model(
 
     Args:
         embedding_type (str, optional): Type of embedding model to use ('openai', 'huggingface', or 'ollama').
-            Defaults to env var EMBEDDING_TYPE or 'openai'.
+            May be passed as ``provider`` for compatibility. Defaults to env var EMBEDDING_TYPE or 'openai'.
         model_name (str, optional): Name of the model to use. Defaults vary by embedding type:
             - OpenAI: env var OPENAI_EMBEDDING_MODEL or 'text-embedding-ada-002'
             - HuggingFace: env var HUGGINGFACE_EMBEDDING_MODEL or 'BAAI/bge-small-en-v1.5'
@@ -50,7 +50,11 @@ def load_embedding_model(
         OLLAMA_MODEL: Model name for Ollama embeddings
         OLLAMA_API_BASE_URL: Base URL for Ollama API
     """
-    embedding_type = embedding_type or os.getenv("EMBEDDING_TYPE", "openai").lower()
+    embedding_type = (
+        embedding_type or kwargs.pop("provider", None) or os.getenv("EMBEDDING_TYPE", "openai")
+    )
+    if embedding_type:
+        embedding_type = str(embedding_type).lower()
     
     if embedding_type == "openai":
         model_name = model_name or os.getenv("OPENAI_EMBEDDING_MODEL", "text-embedding-ada-002")

--- a/factchecker/core/ollama_batch_embedding.py
+++ b/factchecker/core/ollama_batch_embedding.py
@@ -1,0 +1,45 @@
+"""Ollama embedding that uses the batch API (/api/embed with input list) for multiple texts."""
+
+from typing import List
+
+from llama_index.embeddings.ollama import OllamaEmbedding
+
+
+class BatchedOllamaEmbedding(OllamaEmbedding):
+    """
+    Ollama embedding that uses the batch API so multiple texts are sent in one request
+    (or chunked by embed_batch_size) instead of one request per text.
+    """
+
+    def _get_text_embeddings(self, texts: List[str]) -> List[List[float]]:
+        """Get text embeddings via Ollama batch API (embed with input list)."""
+        if not texts:
+            return []
+        out: List[List[float]] = []
+        for i in range(0, len(texts), self.embed_batch_size):
+            chunk = texts[i : i + self.embed_batch_size]
+            result = self._client.embed(
+                model=self.model_name,
+                input=chunk,
+                options=self.ollama_additional_kwargs,
+            )
+            # embed() returns dict with "embeddings" key (list of vectors)
+            embeddings = result.get("embeddings", [])
+            out.extend(embeddings)
+        return out
+
+    async def _aget_text_embeddings(self, texts: List[str]) -> List[List[float]]:
+        """Get text embeddings asynchronously via Ollama batch API."""
+        if not texts:
+            return []
+        out: List[List[float]] = []
+        for i in range(0, len(texts), self.embed_batch_size):
+            chunk = texts[i : i + self.embed_batch_size]
+            result = await self._async_client.embed(
+                model=self.model_name,
+                input=chunk,
+                options=self.ollama_additional_kwargs,
+            )
+            embeddings = result.get("embeddings", [])
+            out.extend(embeddings)
+        return out

--- a/factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback.py
+++ b/factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback.py
@@ -19,7 +19,9 @@ from factchecker.utils.climatefeedback_utils import (
 from factchecker.utils.experiment_utils import (
     configure_logging,
     create_results_dataframe,
+    save_evaluation_errors,
     save_results,
+    show_evaluation_errors,
     verify_environment,
 )
 from factchecker.utils.metrics import calculate_classification_metrics
@@ -177,9 +179,29 @@ def main(experiment_options: Optional[Dict[str, Any]] = None):
     )
 
     # Evaluate claims
-    collectors = evaluate_climatefeedback_claims(strategy, sampled_claims)
+    collectors, errors = evaluate_climatefeedback_claims(strategy, sampled_claims)
 
-    # Create and save results DataFrame
+    # Show errors to the user (summary + details), not only in logs
+    show_evaluation_errors(errors, total_claims=len(sampled_claims))
+
+    total_claims = len(sampled_claims)
+    n_ok = len(collectors['true_labels'])
+    n_err = len(errors)
+    errors_file = None
+
+    # Persist errors to CSV for inspection
+    if errors:
+        errors_file = save_evaluation_errors(errors, base_path="experiments/results", prefix="evaluation_errors")
+        if errors_file:
+            logger.info(f"Evaluation errors saved to: {errors_file}")
+            print(f"Evaluation errors saved to: {errors_file}")
+
+    if n_ok == 0:
+        logger.warning("No claims were successfully evaluated; skipping results and metrics.")
+        print(f"Run summary: 0/{total_claims} claims evaluated successfully. {n_err} errors.")
+        return
+
+    # Create and save results DataFrame (partial results when some claims failed)
     logger.info("Creating results DataFrame...")
     results_df = create_results_dataframe(
         sampled_claims,
@@ -190,7 +212,7 @@ def main(experiment_options: Optional[Dict[str, Any]] = None):
     results_file = save_results(results_df)
     logger.info(f"Results saved to: {results_file}")
 
-    # Calculate and print metrics
+    # Calculate and print metrics (on successful claims only)
     logger.info("Calculating classification metrics...")
     metrics = calculate_classification_metrics(
         collectors['true_labels'],
@@ -199,6 +221,14 @@ def main(experiment_options: Optional[Dict[str, Any]] = None):
     )
     logger.info("\nClassification Metrics:")
     print(metrics)
+
+    # Run summary utilizing error output
+    summary = f"Run summary: {n_ok}/{total_claims} claims evaluated successfully."
+    if n_err:
+        summary += f" {n_err} errors."
+        if errors_file:
+            summary += f" Details: {errors_file}"
+    print(f"\n{summary}")
 
 
 if __name__ == "__main__":

--- a/factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback.py
+++ b/factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback.py
@@ -41,6 +41,7 @@ EXPERIMENT_PARAMS = {
 
     # Indexing parameters
     'main_source_directory': 'data/sources',
+    'index_path': 'data/indices/advocate_mediator_climatefeedback',  # Persist vector store for reuse
 
     # Sources download (CSV -> PDFs)
     'sources_csv': 'factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback_sources.csv',
@@ -125,8 +126,12 @@ def setup_strategy(params: Optional[Dict[str, Any]] = None, downloaded_files: Op
         'embedding_type', 'embedding_model', 'show_progress'
     )}
     if indexer_overrides:
+        base_index_path = indexer_overrides.pop('index_path', None)
         for opts in indexer_options_list:
             opts.update(indexer_overrides)
+            # Per-indexer persist path so multiple indexers don't overwrite
+            if base_index_path:
+                opts['index_path'] = os.path.join(base_index_path, opts['index_name'])
 
     retriever_options_list = [{'top_k': p['top_k']} for _ in indexer_options_list]
 

--- a/factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback.py
+++ b/factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from pathlib import Path
+from typing import Any, Dict, Optional
 
 from llama_index.core import Settings
 
@@ -25,20 +26,29 @@ from factchecker.utils.metrics import calculate_classification_metrics
 
 logger = logging.getLogger(__name__)
 
-# Experiment Parameters
+# Experiment Parameters (all controllable; overridable via main(experiment_options=...))
 EXPERIMENT_PARAMS = {
     # Dataset parameters
     'dataset_path': 'datasets/Combined_Overview_Climate_Feedback_Claims.csv',
     'total_samples': 10,  # Reduced from 100 to work with available data
     'correct_ratio': 0.3,  # Ratio of correct claims in sample
-    
+
     # Document processing parameters
     'chunk_size': 150,  # Size of text chunks for indexing
     'chunk_overlap': 20,  # Overlap between chunks
-    
+
     # Indexing parameters
     'main_source_directory': 'data/sources',
-    
+
+    # Sources download (CSV -> PDFs)
+    'sources_csv': 'factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback_sources.csv',
+    'sources_output_folder': 'data/sources',
+    'sources_skip_existing': True,
+    'sources_max_sources': 1,  # 1 for quick run; set None to download all sources
+    'sources_url_column': 'url',
+    'sources_output_filename_column': 'output_filename',
+    'sources_output_subfolder_column': 'output_subfolder',
+
     # Retrieval parameters
     'top_k': 8,  # Number of similar chunks to retrieve
 
@@ -46,53 +56,81 @@ EXPERIMENT_PARAMS = {
     'label_options': ['correct', 'incorrect', 'not_enough_information'],
 }
 
-def setup_sources(csv_file: str, output_folder: str) -> list[str]:
-    """Download the sources for the indices."""
+
+def setup_sources(params: Optional[Dict[str, Any]] = None) -> list[str]:
+    """Download the sources for the indices. Uses EXPERIMENT_PARAMS unless params override."""
+    p = {**EXPERIMENT_PARAMS, **(params or {})}
+    output_folder = p['sources_output_folder']
     downloader = SourcesDownloader(output_folder=output_folder)
     downloaded_files = downloader.download_pdfs_from_csv(
-        csv_file, 
+        p['sources_csv'],
         row_indices=None,
-        url_column="url",
-        output_filename_column="output_filename",
-        output_subfolder_column="output_subfolder",
-        )
+        url_column=p['sources_url_column'],
+        output_filename_column=p['sources_output_filename_column'],
+        output_subfolder_column=p['sources_output_subfolder_column'],
+        skip_existing=p['sources_skip_existing'],
+        max_sources=p.get('sources_max_sources'),
+    )
     logging.info(f"Downloaded files: {downloaded_files}")
     return downloaded_files
 
-def setup_strategy() -> AdvocateMediatorStrategy:
-    """Sets up the advocate-mediator strategy with experiment-specific options."""
+def setup_strategy(params: Optional[Dict[str, Any]] = None, downloaded_files: Optional[list] = None) -> AdvocateMediatorStrategy:
+    """Sets up the advocate-mediator strategy. Uses EXPERIMENT_PARAMS unless params override."""
     verify_environment()
-    
-    # Configure LlamaIndex parameters for this experiment
-    Settings.chunk_size = EXPERIMENT_PARAMS['chunk_size']
-    Settings.chunk_overlap = EXPERIMENT_PARAMS['chunk_overlap']
-    
-    main_source_directory = EXPERIMENT_PARAMS['main_source_directory']
+    p = {**EXPERIMENT_PARAMS, **(params or {})}
 
-    # Create an indexer for each subfolder in the main sources directory
-    indexer_options_list = [
-        {
-            'source_directory': os.path.join(main_source_directory, "ipcc"),
-            'index_name': "ipcc"
-        },
-        {
-            'source_directory': os.path.join(main_source_directory, "wmo"),
-            'index_name': "wmo"
-        },
-        {
-            'source_directory': os.path.join(main_source_directory, "nipcc"),
-            'index_name': "nipcc"
-        },
-    ]
-    
-    # Create a retriever options list for each indexer.
-    retriever_options_list = [{
-        'top_k': EXPERIMENT_PARAMS['top_k'],
-    } for _ in indexer_options_list]
+    # Configure LlamaIndex parameters for this experiment
+    Settings.chunk_size = p['chunk_size']
+    Settings.chunk_overlap = p['chunk_overlap']
+
+    main_source_directory = p['main_source_directory']
+    max_sources = p.get('sources_max_sources')
+
+    # When we have a list of specific files (e.g. from download limit or local folder): load only those
+    if downloaded_files:
+        indexer_options_list = [
+            {
+                'files': downloaded_files,
+                'index_name': "ipcc",
+            },
+        ]
+    elif max_sources is not None and max_sources <= 1:
+        indexer_options_list = [
+            {
+                'source_directory': os.path.join(main_source_directory, "ipcc"),
+                'index_name': "ipcc",
+            },
+        ]
+    else:
+        # Create an indexer for each subfolder in the main sources directory
+        indexer_options_list = [
+            {
+                'source_directory': os.path.join(main_source_directory, "ipcc"),
+                'index_name': "ipcc"
+            },
+            {
+                'source_directory': os.path.join(main_source_directory, "wmo"),
+                'index_name': "wmo"
+            },
+            {
+                'source_directory': os.path.join(main_source_directory, "nipcc"),
+                'index_name': "nipcc"
+            },
+        ]
+    # Merge any indexer overrides (e.g. chunk_size, embed_batch_size from run_experiments)
+    indexer_overrides = {k: v for k, v in p.items() if k in (
+        'chunk_size', 'chunk_overlap', 'embed_batch_size', 'index_path',
+        'embedding_type', 'embedding_model', 'show_progress'
+    )}
+    if indexer_overrides:
+        for opts in indexer_options_list:
+            opts.update(indexer_overrides)
+
+    retriever_options_list = [{'top_k': p['top_k']} for _ in indexer_options_list]
 
     advocate_options = {
         'system_prompt': advocate_primer,
-        'label_options': EXPERIMENT_PARAMS['label_options'],
+        'label_options': p['label_options'],
     }
 
     evidence_options = {}
@@ -111,25 +149,31 @@ def setup_strategy() -> AdvocateMediatorStrategy:
     logger.info("Strategy initialized successfully")
     return strategy
 
-def main():
-    # Configure logging
+def main(experiment_options: Optional[Dict[str, Any]] = None):
+    """
+    Run the advocate-mediator climatefeedback experiment.
+
+    All behaviour is controlled by EXPERIMENT_PARAMS; pass experiment_options to override
+    (e.g. from run_experiments.py or CLI). Keys can include: sources_csv, sources_output_folder,
+    sources_skip_existing, sources_max_sources, sources_url_column, sources_output_filename_column,
+    sources_output_subfolder_column, chunk_size, chunk_overlap, main_source_directory, top_k,
+    dataset_path, total_samples, correct_ratio, label_options, embed_batch_size, etc.
+    """
     configure_logging()
+    params = {**EXPERIMENT_PARAMS, **(experiment_options or {})}
 
-    # Download sources
-    setup_sources(
-        csv_file="factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback_sources.csv",
-        output_folder="data/sources"
-    )
+    # Download sources (fully controlled by params)
+    downloaded_files = setup_sources(params=params)
 
-    # Setup strategy
-    strategy = setup_strategy()
+    # Setup strategy (uses params; when sources_max_sources<=1, pass files so we load only those)
+    strategy = setup_strategy(params=params, downloaded_files=downloaded_files)
 
-    # Load and sample claims ensuring balanced dataset
+    # Load and sample claims
     logger.info("Loading and sampling claims...")
     sampled_claims = sample_climatefeedback_claims(
-        csv_path=EXPERIMENT_PARAMS['dataset_path'],
-        total_samples=EXPERIMENT_PARAMS['total_samples'],
-        correct_ratio=EXPERIMENT_PARAMS['correct_ratio']
+        csv_path=params['dataset_path'],
+        total_samples=params['total_samples'],
+        correct_ratio=params['correct_ratio']
     )
 
     # Evaluate claims
@@ -142,7 +186,7 @@ def main():
         collectors,
         verdict_mapper=map_verdict
     )
-    
+
     results_file = save_results(results_df)
     logger.info(f"Results saved to: {results_file}")
 
@@ -155,6 +199,7 @@ def main():
     )
     logger.info("\nClassification Metrics:")
     print(metrics)
+
 
 if __name__ == "__main__":
     main()

--- a/factchecker/indexing/abstract_indexer.py
+++ b/factchecker/indexing/abstract_indexer.py
@@ -108,6 +108,8 @@ class AbstractIndexer(ABC):
     def initialize_index(self) -> None:
         """
         Initializes the index by loading an existing index or building a new one.
+        If index_path is set and a persisted index exists, loads from disk.
+        Otherwise builds from documents and, if index_path is set, persists to disk.
 
         Raises:
             Exception: If an error occurs during index initialization.
@@ -116,11 +118,19 @@ class AbstractIndexer(ABC):
         if self.index is not None:
             logger.info("In-memory index already exists. Skipping creation.")
             return
-        
+
+        if self.index_path and self.check_persisted_index_exists():
+            logger.info("Loading existing index from %s", self.index_path)
+            self.load_index()
+            return
+
         try:
             logger.info("No existing index found. Building a new index...")
             documents = self.load_initial_documents()
             self.build_index(documents)
+            if self.index_path:
+                logger.info("Persisting index to %s", self.index_path)
+                self.save_index()
 
         except FileNotFoundError as e:
             logger.error(f"File not found during initialization: {e}")

--- a/factchecker/indexing/abstract_indexer.py
+++ b/factchecker/indexing/abstract_indexer.py
@@ -129,8 +129,12 @@ class AbstractIndexer(ABC):
             documents = self.load_initial_documents()
             self.build_index(documents)
             if self.index_path:
-                logger.info("Persisting index to %s", self.index_path)
-                self.save_index()
+                try:
+                    logger.info("Persisting index to %s", self.index_path)
+                    self.save_index()
+                except NotImplementedError:
+                    # Some indexers (e.g. RagatouilleColBERT) persist during build_index()
+                    logger.debug("save_index not implemented; index may already be persisted by build")
 
         except FileNotFoundError as e:
             logger.error(f"File not found during initialization: {e}")

--- a/factchecker/indexing/abstract_indexer.py
+++ b/factchecker/indexing/abstract_indexer.py
@@ -7,6 +7,9 @@ import logging
 
 from llama_index.core import SimpleDirectoryReader, Document
 
+logger = logging.getLogger(__name__)
+
+
 class AbstractIndexer(ABC):
     """
     Abstract base class for creating and managing indexes.
@@ -56,33 +59,34 @@ class AbstractIndexer(ABC):
         try:
             # Use preloaded documents if provided
             if self.initial_documents:
-                logging.info("Using preloaded documents provided in options.")
+                logger.info("Using preloaded documents provided in options.")
                 return self.initial_documents
 
             # Use specified files if provided
             if self.initial_files:
                 files = self.initial_files
-                logging.info(f"Loading documents from specified files: {files}")
+                logger.info(f"Loading documents from specified files: {files}")
                 documents = SimpleDirectoryReader(input_files=files).load_data()
                 self.initial_documents = documents
-                logging.debug(f"Loaded {len(documents)} documents from specified files")
+                logger.debug(f"Loaded {len(documents)} documents from specified files")
                 return documents
 
             # Load from source directory
             if self.source_directory:
-                logging.info(f"Loading documents from source directory: {self.source_directory}")
+                logger.info(f"Loading documents from source directory: {self.source_directory}")
+                logger.info("Parsing PDF(s)... this may take several minutes for large files.")
                 documents = SimpleDirectoryReader(self.source_directory).load_data()
                 self.initial_documents = documents
-                logging.debug(f"Loaded {len(documents)} documents from {self.source_directory}")
+                logger.info(f"Loaded {len(documents)} documents from {self.source_directory}")
                 return documents
             
             raise ValueError("No documents, files or source directory provided for indexing.")
 
         except FileNotFoundError as e:
-            logging.error(f"File not found during document loading: {e}")
+            logger.error(f"File not found during document loading: {e}")
             raise
         except Exception as e:
-            logging.exception(f"An error occurred while loading documents: {e}")
+            logger.exception(f"An error occurred while loading documents: {e}")
             raise
 
         
@@ -95,9 +99,9 @@ class AbstractIndexer(ABC):
             
         """
         if self.index_path and os.path.exists(self.index_path):
-            logging.debug(f"Index exists at {self.index_path}")
+            logger.debug(f"Index exists at {self.index_path}")
             return True
-        logging.debug("No persisted index found.")
+        logger.debug("No persisted index found.")
         return False
 
 
@@ -110,19 +114,19 @@ class AbstractIndexer(ABC):
 
         """
         if self.index is not None:
-            logging.info("In-memory index already exists. Skipping creation.")
+            logger.info("In-memory index already exists. Skipping creation.")
             return
         
         try:
-            logging.info("No existing index found. Building a new index...")
+            logger.info("No existing index found. Building a new index...")
             documents = self.load_initial_documents()
             self.build_index(documents)
 
         except FileNotFoundError as e:
-            logging.error(f"File not found during initialization: {e}")
+            logger.error(f"File not found during initialization: {e}")
             raise
         except ValueError as e:
-            logging.error(f"Invalid data provided: {e}")
+            logger.error(f"Invalid data provided: {e}")
             raise
 
     @abstractmethod

--- a/factchecker/indexing/llama_vector_store_indexer.py
+++ b/factchecker/indexing/llama_vector_store_indexer.py
@@ -1,14 +1,18 @@
 """LlamaVectorStoreIndexer class."""
 
 import logging
+import os
 from typing import Any, Optional
 
 from llama_index.core import Document, Settings, StorageContext, VectorStoreIndex
 from llama_index.core.embeddings.utils import EmbedType
+from llama_index.core.indices import load_index_from_storage
 from llama_index.core.node_parser import SentenceSplitter
 
 from factchecker.indexing.abstract_indexer import AbstractIndexer
 from factchecker.core.embeddings import load_embedding_model
+
+logger = logging.getLogger(__name__)
 
 
 class LlamaVectorStoreIndexer(AbstractIndexer):
@@ -72,7 +76,7 @@ class LlamaVectorStoreIndexer(AbstractIndexer):
 
         """
         try:
-
+            logger.info("Building vector index (chunking and embedding documents)...")
             storage_context = StorageContext.from_defaults(**self.storage_context_options)
             
             self.index = VectorStoreIndex.from_documents(
@@ -82,33 +86,48 @@ class LlamaVectorStoreIndexer(AbstractIndexer):
                 transformations=self.transformations,
                 show_progress=self.show_progress,
             )
-            logging.info("VectorStoreIndex successfully built")
+            logger.info("VectorStoreIndex successfully built")
         
         except Exception as e:
-            logging.exception(f"Failed to create LlamaVectorStore index: {e}")
+            logger.exception(f"Failed to create LlamaVectorStore index: {e}")
             raise
 
-    def save_index(self) -> None:
+    def save_index(self, index_path: Optional[str] = None) -> None:
         """
         Save the LlamaVectorStore index to disk.
 
-        Raises:
-            NotImplementedError: If the method is not yet implemented.
+        Args:
+            index_path (Optional[str]): Path where the index will be saved.
+                Defaults to self.index_path. Required if self.index_path is not set.
 
+        Raises:
+            ValueError: If no index_path is available and none is provided.
         """
-        logging.error("save_index() of LlamaVectorStoreIndexer is not yet implemented")
-        raise NotImplementedError("save_index() of LlamaVectorStoreIndexer is not yet implemented")
+        persist_dir = index_path or self.index_path
+        if not persist_dir:
+            raise ValueError("index_path is required to save the index")
+        if self.index is None:
+            raise ValueError("No index to save; build the index first")
+        os.makedirs(persist_dir, exist_ok=True)
+        self.index.storage_context.persist(persist_dir=persist_dir)
+        logger.info("VectorStoreIndex saved to %s", persist_dir)
 
     def load_index(self) -> None:
         """
         Load the LlamaVectorStore index from disk.
 
         Raises:
-            NotImplementedError: If the method is not yet implemented.
-
+            ValueError: If index_path is not set or no persisted index exists.
         """
-        logging.error("load_index() of LlamaVectorStoreIndexer is not yet implemented")
-        raise NotImplementedError("load_index() of LlamaVectorStoreIndexer is not yet implemented")
+        if not self.index_path:
+            raise ValueError("index_path is required to load the index")
+        if not os.path.isdir(self.index_path):
+            raise ValueError(f"No persisted index found at {self.index_path}")
+        storage_context = StorageContext.from_defaults(persist_dir=self.index_path)
+        self.index = load_index_from_storage(
+            storage_context, embed_model=self.embed_model
+        )
+        logger.info("VectorStoreIndex loaded from %s", self.index_path)
 
     def add_to_index(self, documents: list[Document]) -> None:
         """
@@ -121,7 +140,7 @@ class LlamaVectorStoreIndexer(AbstractIndexer):
             NotImplementedError: If the method is not yet implemented.
 
         """
-        logging.error("add_to_index() of LlamaVectorStoreIndexer is not yet implemented")
+        logger.error("add_to_index() of LlamaVectorStoreIndexer is not yet implemented")
         raise NotImplementedError("add_to_index() of LlamaVectorStoreIndexer is not yet implemented")
 
     def delete_from_index(self, document_ids: list[str]) -> None:
@@ -135,5 +154,5 @@ class LlamaVectorStoreIndexer(AbstractIndexer):
             NotImplementedError: If the method is not yet implemented.
 
         """
-        logging.error("delete_from_index() of LlamaVectorStoreIndexer is not yet implemented")
+        logger.error("delete_from_index() of LlamaVectorStoreIndexer is not yet implemented")
         raise NotImplementedError("delete_from_index() of LlamaVectorStoreIndexer is not yet implemented")

--- a/factchecker/steps/advocate.py
+++ b/factchecker/steps/advocate.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Callable, Optional, Tuple
 
 from llama_index.core.llms import ChatMessage
 
@@ -8,6 +9,26 @@ from factchecker.datastructures import LabelOption
 from factchecker.prompts.advocate_prompts import get_default_system_prompt, get_default_user_prompt
 from factchecker.retrieval.abstract_retriever import AbstractRetriever
 from factchecker.steps.evidence import EvidenceStep
+from factchecker.steps.verdict_retry import chat_with_verdict_retry
+
+logger = logging.getLogger(__name__)
+
+# Format we require from the LLM; repeated in retry instructions
+ADVOCATE_VERDICT_FORMAT = (
+    "Respond with exactly one verdict in double parentheses: ((correct)), ((incorrect)), or ((not_enough_information)). "
+    "Put your reasoning first, then the verdict at the end, e.g. \"Your reasoning here. ((correct))\"."
+)
+
+
+def _default_advocate_parser(response_content: str) -> Optional[Tuple[str, str]]:
+    """Extract verdict and reasoning from response using (( )) format. Returns (label, reasoning) or None."""
+    start = response_content.find("((")
+    end = response_content.find("))")
+    if start == -1 or end == -1:
+        return None
+    label = response_content[start + 2 : end].strip().upper().replace(" ", "_")
+    reasoning = (response_content[:start].strip() + " " + response_content[end + 2 :].strip()).strip()
+    return label, reasoning
 
 
 class AdvocateStep:
@@ -49,6 +70,8 @@ class AdvocateStep:
         self.label_options = self.options.pop('label_options', DEFAULT_LABEL_OPTIONS)
         self.max_retries = self.options.pop('max_retries', 3)
         self.chat_completion_options = self.options.pop('chat_completion_options', {})
+        # Optional custom parser: (response_content: str) -> Optional[Tuple[label, reasoning]]
+        self.verdict_parser: Optional[Callable[[str], Optional[Tuple[str, str]]]] = self.options.pop('verdict_parser', None)
         
         # Initialize EvidenceStep
         self.evidence_step = EvidenceStep(
@@ -92,20 +115,16 @@ class AdvocateStep:
             ChatMessage(role="system", content=self.system_prompt),
             ChatMessage(role="user", content=user_prompt)
         ]
-
-
-        for attempt in range(self.max_retries):
-            response = self.llm.chat(messages, **self.chat_completion_options)
-            response_content = response.message.content.strip()
-            # Extract the verdict from the response
-            start = response_content.find("((")
-            end = response_content.find("))")
-            if start != -1 and end != -1:
-                label = response_content[start+2:end].strip().upper().replace(" ", "_")
-                # Remove the label inside (( )) from the response content
-                reasoning = response_content[:start].strip() + response_content[end+2:].strip()
-                return label, reasoning
-            else:
-                logging.warning(f"Unexpected response content on attempt {attempt + 1}: {response_content}")
-        
+        parse_fn = self.verdict_parser if self.verdict_parser is not None else _default_advocate_parser
+        result = chat_with_verdict_retry(
+            messages,
+            self.llm,
+            parse_fn,
+            ADVOCATE_VERDICT_FORMAT,
+            self.max_retries,
+            self.chat_completion_options,
+            logger,
+        )
+        if result is not None:
+            return result[0], result[1]
         return "ERROR_PARSING_RESPONSE", "No reasoning available"

--- a/factchecker/steps/mediator.py
+++ b/factchecker/steps/mediator.py
@@ -46,10 +46,9 @@ class MediatorStep:
         self.llm = llm if llm is not None else load_llm()
         self.options = options if options is not None else {}
         self.system_prompt = self.options.pop('system_prompt', '')
-        self.additional_options = {key: self.options.pop(key) for key in list(self.options.keys())}
         self.max_retries = self.options.pop('max_retries', 3)
-        # Optional custom parser: (response_content: str) -> Optional[verdict_str]
         self.verdict_parser: Optional[Callable[[str], Optional[str]]] = self.options.pop('verdict_parser', None)
+        self.additional_options = {key: self.options.pop(key) for key in list(self.options.keys())}
 
     def synthesize_verdicts(self, verdicts_and_reasonings, claim):
         """

--- a/factchecker/steps/mediator.py
+++ b/factchecker/steps/mediator.py
@@ -1,7 +1,30 @@
-from llama_index.core.llms import ChatMessage
 import logging
-import os
+from typing import Callable, Optional
+
+from llama_index.core.llms import ChatMessage
+
 from factchecker.core.llm import load_llm
+
+from factchecker.steps.verdict_retry import chat_with_verdict_retry
+
+logger = logging.getLogger(__name__)
+
+# Format we require from the LLM; repeated in retry instructions
+MEDIATOR_VERDICT_FORMAT = (
+    "Provide the final verdict as exactly one of: ((correct)), ((incorrect)), or ((not_enough_information)). "
+    "Use double parentheses with the single word inside, nothing else."
+)
+
+
+def _default_mediator_parser(response_content: str) -> Optional[str]:
+    """Extract final verdict from response using (( )) format. Returns verdict string or None."""
+    start = response_content.find("((")
+    end = response_content.find("))")
+    if start == -1 or end == -1:
+        return None
+    verdict = response_content[start + 2 : end].strip().upper().replace(" ", "_")
+    return verdict
+
 
 class MediatorStep:
     """
@@ -24,7 +47,9 @@ class MediatorStep:
         self.options = options if options is not None else {}
         self.system_prompt = self.options.pop('system_prompt', '')
         self.additional_options = {key: self.options.pop(key) for key in list(self.options.keys())}
-        self.max_retries = 3
+        self.max_retries = self.options.pop('max_retries', 3)
+        # Optional custom parser: (response_content: str) -> Optional[verdict_str]
+        self.verdict_parser: Optional[Callable[[str], Optional[str]]] = self.options.pop('verdict_parser', None)
 
     def synthesize_verdicts(self, verdicts_and_reasonings, claim):
         """
@@ -42,23 +67,24 @@ class MediatorStep:
             [f"<verdict>{verdict}</verdict><reasoning>{reasoning}</reasoning>" for verdict, reasoning in verdicts_and_reasonings]
         )
         
+        user_content = (
+            f"Here are the verdicts and reasonings of the different advocates:\n{formatted_verdicts_and_reasonings}\n"
+            f"Please provide the final verdict as ((correct)), ((incorrect)), or ((not_enough_information)) for the claim: {claim}"
+        )
         messages = [
             ChatMessage(role="system", content=self.system_prompt),
-            ChatMessage(role="user", content=f"Here are the verdicts and reasonings of the different advocates:\n{formatted_verdicts_and_reasonings}\nPlease provide the final verdict as ((correct)), ((incorrect)), or ((not_enough_information)) for the claim: {claim}")
+            ChatMessage(role="user", content=user_content)
         ]
-        
-        valid_options = {key: value for key, value in self.additional_options.items() if key in ["response_format", "temperature", "max_tokens", "top_p", "frequency_penalty", "presence_penalty"]}
 
-        for attempt in range(self.max_retries):
-            response = self.llm.chat(messages, **valid_options)
-            response_content = response.message.content.strip()
-            # Extract the final verdict from the response
-            start = response_content.find("((")
-            end = response_content.find("))")
-            if start != -1 and end != -1:
-                final_verdict = response_content[start+2:end].strip().upper().replace(" ", "_")
-                return final_verdict
-            else:
-                logging.warning(f"Unexpected response content on attempt {attempt + 1}: {response_content}")
-        
-        return "ERROR_PARSING_RESPONSE"
+        valid_options = {key: value for key, value in self.additional_options.items() if key in ["response_format", "temperature", "max_tokens", "top_p", "frequency_penalty", "presence_penalty"]}
+        parse_fn = self.verdict_parser if self.verdict_parser is not None else _default_mediator_parser
+        result = chat_with_verdict_retry(
+            messages,
+            self.llm,
+            parse_fn,
+            MEDIATOR_VERDICT_FORMAT,
+            self.max_retries,
+            valid_options,
+            logger,
+        )
+        return result if result is not None else "ERROR_PARSING_RESPONSE"

--- a/factchecker/steps/verdict_retry.py
+++ b/factchecker/steps/verdict_retry.py
@@ -1,0 +1,66 @@
+"""
+Shared retry logic for LLM verdict parsing.
+
+When the model returns a verdict in the wrong format, we append a follow-up message
+showing the last response and the required format, then retry. Used by AdvocateStep
+and MediatorStep.
+"""
+import logging
+from typing import Any, Callable, List, Optional, TypeVar
+
+from llama_index.core.llms import ChatMessage
+
+T = TypeVar("T")
+
+
+def chat_with_verdict_retry(
+    messages: List[ChatMessage],
+    llm: Any,
+    parse_fn: Callable[[str], Optional[T]],
+    format_instruction: str,
+    max_retries: int,
+    chat_kwargs: dict,
+    logger: logging.Logger,
+) -> Optional[T]:
+    """
+    Call the LLM in a loop; parse each response with parse_fn. On invalid format,
+    append a retry user message (last answer + format instruction) and try again.
+
+    Args:
+        messages: Initial chat messages (system + user).
+        llm: LLM instance with .chat(messages, **kwargs).
+        parse_fn: Function that returns parsed result or None if format invalid.
+        format_instruction: Text to show the model when retrying (required format).
+        max_retries: Maximum number of chat attempts.
+        chat_kwargs: Extra kwargs for llm.chat().
+        logger: Logger for attempt/retry messages.
+
+    Returns:
+        Parsed result from parse_fn, or None if all attempts failed.
+    """
+    for attempt in range(max_retries):
+        response = llm.chat(messages, **chat_kwargs)
+        response_content = response.message.content.strip()
+        result = parse_fn(response_content)
+        if result is not None:
+            log_label = result[0] if isinstance(result, tuple) else result
+            logger.info(
+                "Attempt %s response (parsed): %s -> %s",
+                attempt + 1,
+                response_content[:200] + ("..." if len(response_content) > 200 else ""),
+                log_label,
+            )
+            return result
+        logger.warning("Attempt %s response (invalid format): %s", attempt + 1, response_content)
+        logger.info("Model response on attempt %s (could not parse): %s", attempt + 1, response_content)
+        if attempt < max_retries - 1:
+            logger.info("Sending format feedback and retrying (attempt %s of %s).", attempt + 2, max_retries)
+            preview = response_content[:500] + ("..." if len(response_content) > 500 else "")
+            retry_user = (
+                "Your previous response was in the wrong format.\n\n"
+                "This was your last answer (format is wrong):\n{preview}\n\n"
+                "Stick to the format: {format_instruction}"
+            ).format(preview=preview, format_instruction=format_instruction)
+            messages.append(ChatMessage(role="assistant", content=response_content))
+            messages.append(ChatMessage(role="user", content=retry_user))
+    return None

--- a/factchecker/tools/sources_downloader.py
+++ b/factchecker/tools/sources_downloader.py
@@ -2,6 +2,7 @@ import argparse
 import csv
 import logging
 import os
+from typing import List, Optional
 from urllib.parse import urlparse
 
 import requests
@@ -102,20 +103,22 @@ class SourcesDownloader:
             return False
 
     def download_pdfs_from_csv(
-            self, 
-            sourcefile: str = "sources/sources.csv", 
-            row_indices: list[int] | None = None, 
-            url_column: str = "url",
-            output_filename_column: str = "output_filename",
+            self,
+            sourcefile: str = "sources/sources.csv",
+            row_indices: Optional[List[int]] = None,
+            url_column: str = "external_link",
+            output_filename_column: str = "pdf_title",
             output_subfolder_column: str = "output_subfolder",
-        ) -> list[str]:
+            skip_existing: bool = True,
+            max_sources: Optional[int] = None,
+        ) -> List[str]:
         """
         Download source documents from URLs specified in a claims database CSV file.
-        
+
         This function processes a CSV file containing fact-checking claims and their associated
         source documents. It downloads the source documents that support or are referenced by the claims,
         maintaining the connection between claims and their supporting evidence.
-        
+
         Args:
             sourcefile (str): Path to the CSV file containing claims and their source URLs.
             row_indices (list[int], optional): List of specific claim indices to download sources for.
@@ -123,50 +126,61 @@ class SourcesDownloader:
             url_column (str): Name of the column containing source document URLs.
             output_filename_column (str): Name of the column specifying the filename for the downloaded file
             output_subfolder_column (str): Name of the column specifying the subfolder where to download each file
+            skip_existing (bool): If True, skip rows where the output file already exists. Default True.
+            max_sources (int, optional): If set, stop after this many successful downloads. Default None.
 
         Raises:
             FileNotFoundError: If the specified CSV file does not exist.
             KeyError: If the specified url_column does not exist in the CSV file.
-        
+
         Returns:
-            list[str]: A list of file paths for the downloaded documents.
+            list[str]: A list of file paths for the downloaded (or skipped existing) documents.
 
         """
         downloaded_files = []
-        
+
         # Check if file exists before attempting to open it
         if not os.path.isfile(sourcefile):
             logger.error(f"Source file not found: {sourcefile}")
             raise FileNotFoundError(f"Source file not found: {sourcefile}")
-        
+
         with open(sourcefile, 'r') as csvfile:
             reader = csv.DictReader(csvfile, skipinitialspace=True)
-            
+
             # Validate that required columns exist
             if reader.fieldnames and url_column not in reader.fieldnames:
                 logger.error(f"Column {url_column} does not exist in the CSV file.")
                 raise KeyError(f"Column {url_column} does not exist in the CSV file.")
-            
+
             for i, row in enumerate(reader):
+                if max_sources is not None and len(downloaded_files) >= max_sources:
+                    break
                 if row_indices and i not in row_indices:
                     continue
-                
+
                 url = row.get(url_column, "").strip()
                 if not url:
                     logger.warning(f"Empty URL in row {i}, skipping")
                     continue
-                    
+
                 output_filename = row.get(output_filename_column, f"document_{i}.pdf")
+                if not output_filename.lower().endswith('.pdf'):
+                    output_filename += '.pdf'
                 subfolder = row.get(output_subfolder_column, "").strip()
                 output_folder = os.path.join(self.output_folder, subfolder) if subfolder else self.output_folder
-                
+                pdf_path = os.path.join(output_folder, output_filename)
+
                 if not os.path.exists(output_folder):
                     os.makedirs(output_folder)
-                
+
+                if skip_existing and os.path.exists(pdf_path):
+                    downloaded_files.append(pdf_path)
+                    continue
+
                 success = self.download_pdf(url, output_folder, output_filename)
                 if success:
-                    downloaded_files.append(os.path.join(output_folder, output_filename))
-                
+                    downloaded_files.append(pdf_path)
+
         return downloaded_files
 
     @staticmethod
@@ -202,11 +216,11 @@ class SourcesDownloader:
             help='Specify which claims to download sources for (0-indexed).'
         )
         parser.add_argument(
-            '--url_column', type=str, default='url',
+            '--url_column', type=str, default='external_link',
             help='Specify the column containing source URLs.'
         )
         parser.add_argument(
-            '--output_filename_column', type=str, default='output_filename',
+            '--output_filename_column', type=str, default='pdf_title',
             help='Specify the column containing filenames for downloaded files.'
         )
         parser.add_argument(
@@ -217,16 +231,26 @@ class SourcesDownloader:
             '--output_folder', type=str, default='data/sources',
             help='Main output folder for the downloaded source documents.'
         )
+        parser.add_argument(
+            '--limit', type=int, default=None,
+            help='Maximum number of sources to download (first N).'
+        )
+        parser.add_argument(
+            '--no-skip-existing', action='store_true',
+            help='Re-download even if file already exists.'
+        )
         args = parser.parse_args()
 
         downloader = SourcesDownloader(args.output_folder)
         try:
             downloader.download_pdfs_from_csv(
-                args.sourcefile, 
-                args.row_indices, 
+                args.sourcefile,
+                args.row_indices,
                 args.url_column,
                 args.output_filename_column,
-                args.output_subfolder_column
+                args.output_subfolder_column,
+                skip_existing=not args.no_skip_existing,
+                max_sources=args.limit,
             )
         except (FileNotFoundError, KeyError) as e:
             logger.error(f"Error: {e}")

--- a/factchecker/utils/climatefeedback_utils.py
+++ b/factchecker/utils/climatefeedback_utils.py
@@ -174,7 +174,8 @@ def evaluate_climatefeedback_claim(
         collectors = collect_evaluation_results(
             collectors,
             (true_label, final_verdict, verdicts, reasonings),
-            num_advocates=len(verdicts) if not collectors['advocate_evidences'] else None
+            num_advocates=len(verdicts) if not collectors['advocate_evidences'] else None,
+            claim_index=claim_index,
         )
         
         logger.debug(f"\nClaim {claim_index + 1}/{total_claims}:")
@@ -189,42 +190,48 @@ def evaluate_climatefeedback_claim(
         
     return collectors
 
-def evaluate_climatefeedback_claims(strategy, sampled_claims, num_advocates: int = 1) -> Dict:
+def evaluate_climatefeedback_claims(strategy, sampled_claims, num_advocates: int = 1) -> Tuple[Dict, List[Dict]]:
     """
     Evaluate a batch of Climate Feedback claims using the provided strategy.
-    
+
     Args:
         strategy: The evaluation strategy to use
         sampled_claims: DataFrame containing claims to evaluate
         num_advocates: Number of advocates in the strategy
-        
+
     Returns:
-        Dictionary containing collected results
-        
-    Raises:
-        ValueError: If sampled_claims is empty or missing required columns
+        Tuple of (collectors, errors). errors is a list of dicts with keys:
+        claim_index, error_type, error_message, claim_preview.
     """
     if sampled_claims.empty:
         raise ValueError("sampled_claims cannot be empty")
-        
+
     if 'Claim' not in sampled_claims.columns or 'Climate Feedback' not in sampled_claims.columns:
         raise ValueError("sampled_claims must contain 'Claim' and 'Climate Feedback' columns")
-    
+
     collectors = initialize_results_collectors(num_advocates)
-    
+    errors: List[Dict] = []
+
     logger.info("Starting claim evaluation...")
     for idx, row in tqdm(sampled_claims.iterrows(), total=len(sampled_claims), desc="Evaluating claims"):
+        claim_text = row['Claim']
         try:
             collectors = evaluate_climatefeedback_claim(
                 strategy=strategy,
-                claim=row['Claim'],
+                claim=claim_text,
                 true_label=row['Climate Feedback'],
                 collectors=collectors,
                 claim_index=idx,
                 total_claims=len(sampled_claims)
             )
         except Exception as e:
-            logger.error(f"Skipping claim {idx + 1} due to error {str(e)}")
+            errors.append({
+                'claim_index': idx,
+                'error_type': type(e).__name__,
+                'error_message': str(e),
+                'claim_preview': (claim_text[:80] + '...') if len(claim_text) > 80 else claim_text,
+            })
+            logger.error(f"Skipping claim (index {idx}) due to error: {e}")
             continue
-            
-    return collectors 
+
+    return collectors, errors 

--- a/factchecker/utils/experiment_utils.py
+++ b/factchecker/utils/experiment_utils.py
@@ -11,11 +11,14 @@ from llama_index.core import Settings
 logger = logging.getLogger(__name__)
 
 def configure_logging():
-    """Configure basic logging for experiments."""
+    """Configure basic logging for experiments. Ensures indexers and LlamaIndex show INFO logs."""
     logging.basicConfig(
         level=logging.INFO,
-        format='%(asctime)s - %(levelname)s - %(message)s'
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
     )
+    # Ensure factchecker and LlamaIndex loggers show INFO (indexing, retrieval, etc.)
+    for name in ('factchecker', 'llama_index', 'root'):
+        logging.getLogger(name).setLevel(logging.INFO)
 
 def configure_llama_index():
     """Configure LlamaIndex settings."""

--- a/factchecker/utils/experiment_utils.py
+++ b/factchecker/utils/experiment_utils.py
@@ -10,6 +10,34 @@ from llama_index.core import Settings
 
 logger = logging.getLogger(__name__)
 
+
+def show_evaluation_errors(errors: List[Dict[str, Any]], total_claims: Optional[int] = None) -> None:
+    """
+    Print evaluation errors to stdout (summary and per-error details), in addition to logging.
+    """
+    if not errors:
+        return
+    n = len(errors)
+    total = total_claims if total_claims is not None else "?"
+    print("\n--- Evaluation errors ---")
+    print(f"Failed claims: {n} / {total}")
+    by_type: Dict[str, int] = {}
+    for e in errors:
+        t = e.get("error_type", "Unknown")
+        by_type[t] = by_type.get(t, 0) + 1
+    print("By error type:", by_type)
+    print("Details:")
+    for e in errors:
+        idx = e.get("claim_index", "?")
+        typ = e.get("error_type", "?")
+        msg = e.get("error_message", "?")
+        preview = e.get("claim_preview", "")
+        print(f"  [{idx}] {typ}: {msg}")
+        if preview:
+            print(f"       Claim: {preview}")
+    print("---\n")
+
+
 def configure_logging():
     """Configure basic logging for experiments. Ensures indexers and LlamaIndex show INFO logs."""
     logging.basicConfig(
@@ -84,50 +112,54 @@ def initialize_results_collectors(num_advocates: int) -> ResultsDict:
         'mediator_reasonings': [],
         'advocate_evidences': [[] for _ in range(num_advocates)],
         'advocate_verdicts': [[] for _ in range(num_advocates)],
-        'advocate_reasonings': [[] for _ in range(num_advocates)]
+        'advocate_reasonings': [[] for _ in range(num_advocates)],
+        'claim_indices': [],
     }
 
 def collect_evaluation_results(
     collectors: ResultsDict,
     claim_data: ClaimData,
-    num_advocates: Optional[int] = None
+    num_advocates: Optional[int] = None,
+    claim_index: Optional[Any] = None,
 ) -> ResultsDict:
     """
     Collects results from a single claim evaluation.
-    
+
     Args:
         collectors: Dictionary of result collectors
         claim_data: Tuple of (true_label, final_verdict, verdicts, reasonings)
         num_advocates: Number of advocates (optional, for initialization)
-        
+        claim_index: Index of the claim in the source DataFrame (for partial-results alignment)
+
     Returns:
         Updated collectors dictionary
-        
-    Raises:
-        ValueError: If collectors is None or empty when num_advocates is None
-        ValueError: If claim_data components don't match expected structure
     """
     if not collectors and num_advocates is None:
         raise ValueError("collectors cannot be empty when num_advocates is None")
-        
+
     true_label, final_verdict, verdicts, reasonings = claim_data
-    
+
     if not isinstance(verdicts, list) or not isinstance(reasonings, list):
         raise ValueError("verdicts and reasonings must be lists")
-    
+
     # Initialize collectors if first run
     if num_advocates is not None and not collectors.get('advocate_evidences'):
         collectors = initialize_results_collectors(num_advocates)
 
-    collectors['true_labels'].append(true_label)
-    collectors['predicted_results'].append(final_verdict)
-    collectors['mediator_reasonings'].append(reasonings[-1])
-    
+    if "claim_indices" not in collectors:
+        collectors["claim_indices"] = []
+
+    collectors["true_labels"].append(true_label)
+    collectors["predicted_results"].append(final_verdict)
+    collectors["mediator_reasonings"].append(reasonings[-1])
+    if claim_index is not None:
+        collectors["claim_indices"].append(claim_index)
+
     for i in range(len(verdicts)):
-        collectors['advocate_evidences'][i].append(verdicts[i])
-        collectors['advocate_verdicts'][i].append(verdicts[i])
-        collectors['advocate_reasonings'][i].append(reasonings[i])
-    
+        collectors["advocate_evidences"][i].append(verdicts[i])
+        collectors["advocate_verdicts"][i].append(verdicts[i])
+        collectors["advocate_reasonings"][i].append(reasonings[i])
+
     return collectors
 
 def create_results_dataframe(
@@ -152,12 +184,20 @@ def create_results_dataframe(
     """
     if 'Claim' not in claims.columns:
         raise ValueError("claims DataFrame must contain 'Claim' column")
-        
-    if len(claims) != len(collectors['true_labels']):
-        raise ValueError("Number of claims doesn't match number of collected results")
-    
+
+    claim_indices = collectors.get('claim_indices')
+    if claim_indices is not None and len(claim_indices) > 0:
+        # Partial results: align claims to successful evaluations only
+        if len(claim_indices) != len(collectors['true_labels']):
+            raise ValueError("claim_indices length must match collected results length")
+        claims_subset = claims.loc[claim_indices].reset_index(drop=True)
+    else:
+        if len(claims) != len(collectors['true_labels']):
+            raise ValueError("Number of claims doesn't match number of collected results")
+        claims_subset = claims
+
     results_dict = {
-        'Claim': claims['Claim'],
+        'Claim': claims_subset['Claim'].values,
         'True Label': collectors['true_labels'],
         'Predicted Verdict': collectors['predicted_results'],
         'Mediator Reasoning': collectors['mediator_reasonings']
@@ -205,4 +245,30 @@ def save_results(
     filename = f"{base_path}/{prefix}_{timestamp}.csv"
     os.makedirs(os.path.dirname(filename), exist_ok=True)
     results_df.to_csv(filename, index=False)
-    return filename 
+    return filename
+
+
+def save_evaluation_errors(
+    errors: List[Dict[str, Any]],
+    base_path: str = "experiments/results",
+    prefix: str = "evaluation_errors",
+) -> Optional[str]:
+    """
+    Save evaluation errors to a timestamped CSV for inspection.
+
+    Args:
+        errors: List of error dicts (claim_index, error_type, error_message, claim_preview)
+        base_path: Directory to save in
+        prefix: Filename prefix
+
+    Returns:
+        Path to the saved file, or None if errors is empty
+    """
+    if not errors:
+        return None
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"{base_path}/{prefix}_{timestamp}.csv"
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
+    df = pd.DataFrame(errors)
+    df.to_csv(filename, index=False)
+    return filename

--- a/run_experiments.py
+++ b/run_experiments.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+Script to run the ClimateCheck fact-checking experiments with optimized settings.
+This uses the updated embeddings and indexer implementations for efficient processing.
+
+Ollama (LLM and embeddings) is controlled via .env: set LLM_TYPE=ollama,
+EMBEDDING_TYPE=ollama, OLLAMA_API_BASE_URL, OLLAMA_MODEL, etc. in .env.
+"""
+
+import os
+import argparse
+import logging
+import time
+from datetime import datetime
+
+# Load .env first so it controls LLM/embedding/Ollama settings
+from dotenv import load_dotenv
+load_dotenv(override=True)
+
+# Setup logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[
+        logging.StreamHandler(),
+        logging.FileHandler(f"logs/experiment_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log")
+    ]
+)
+
+logger = logging.getLogger(__name__)
+
+def setup_environment():
+    """Configure environment settings for the experiment. Ollama is controlled via .env."""
+    # Only set OLLAMA_API_BASE_URL default if not already set (e.g. from .env)
+    if not os.environ.get("OLLAMA_API_BASE_URL"):
+        os.environ["OLLAMA_API_BASE_URL"] = "http://localhost:11434"
+    llm_type = os.environ.get("LLM_TYPE", "openai")
+    emb_type = os.environ.get("EMBEDDING_TYPE", "openai")
+    logger.info(f"Using .env: LLM_TYPE={llm_type}, EMBEDDING_TYPE={emb_type}, OLLAMA_API_BASE_URL={os.environ['OLLAMA_API_BASE_URL']}")
+    if emb_type == "ollama":
+        emb_model = os.environ.get("OLLAMA_EMBEDDING_MODEL") or os.environ.get("OLLAMA_MODEL", "nomic-embed-text")
+        logger.info(f"Ollama embedding model: {emb_model}")
+    # Check if Ollama is available when using Ollama
+    if llm_type == "ollama" or emb_type == "ollama":
+        import httpx
+        try:
+            base = os.environ["OLLAMA_API_BASE_URL"]
+            response = httpx.get(f"{base}/api/tags")
+            if response.status_code == 200:
+                logger.info(f"Ollama server is available at {base}")
+                models = response.json().get("models", [])
+                logger.info(f"Available models: {[m.get('name') for m in models]}")
+            else:
+                logger.warning(f"Ollama server at {base} returned status {response.status_code}")
+        except Exception as e:
+            logger.warning(f"Could not connect to Ollama server: {str(e)}")
+            logger.warning("Set LLM_TYPE=ollama and EMBEDDING_TYPE=ollama in .env and ensure Ollama is running.")
+
+def run_experiment(experiment_options=None):
+    """Run the advocate-mediator experiment with the specified options.
+
+    experiment_options overrides EXPERIMENT_PARAMS inside the experiment (sources, indexing, etc.).
+    """
+    if experiment_options is None:
+        experiment_options = {}
+
+    logger.info("Starting advocate-mediator experiment")
+
+    try:
+        from factchecker.experiments.advocate_mediator_climatefeedback.advocate_mediator_climatefeedback import main
+        logger.info("Using advocate-mediator climatefeedback experiment module")
+
+        start_time = time.time()
+        main(experiment_options=experiment_options)
+        elapsed = time.time() - start_time
+
+        logger.info(f"Experiment completed successfully in {elapsed//60:.0f}m {elapsed%60:.0f}s")
+
+    except ImportError as e:
+        logger.error(f"Could not import the experiment module: {str(e)}")
+        logger.error("Make sure you are in the factchecker directory and have installed the package.")
+        logger.error("Try running: pip install -e .")
+
+    except Exception as e:
+        logger.error(f"Error running experiment: {str(e)}")
+        import traceback
+        logger.error(f"Stack trace: {traceback.format_exc()}")
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Run ClimateCheck fact-checking experiments")
+    
+    parser.add_argument(
+        "--node-batch-size", 
+        type=int, 
+        default=500,
+        help="Batch size for node creation (default: 500)"
+    )
+    
+    parser.add_argument(
+        "--embedding-batch-size", 
+        type=int, 
+        default=32,
+        help="Batch size for embedding (default: 32)"
+    )
+    
+    parser.add_argument(
+        "--num-workers", 
+        type=int, 
+        default=4,
+        help="Number of worker threads (default: 4)"
+    )
+    
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=150,
+        help="Size of text chunks for indexing (default: 150)"
+    )
+    
+    parser.add_argument(
+        "--chunk-overlap",
+        type=int,
+        default=20,
+        help="Overlap between chunks (default: 20)"
+    )
+    
+    parser.add_argument(
+        "--force-rebuild",
+        action="store_true",
+        help="Force rebuilding the index even if it exists"
+    )
+
+    # Sources download (passed into experiment)
+    parser.add_argument(
+        "--sources-limit",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Max number of sources to download (default: no limit)"
+    )
+    parser.add_argument(
+        "--no-skip-existing",
+        action="store_true",
+        help="Re-download sources even if file already exists"
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    setup_environment()
+
+    # All options passed into experiment; experiment uses EXPERIMENT_PARAMS + these overrides
+    experiment_options = {
+        "chunk_size": args.chunk_size,
+        "chunk_overlap": args.chunk_overlap,
+        "embed_batch_size": getattr(args, "embedding_batch_size", 32),
+        "node_batch_size": getattr(args, "node_batch_size", None),
+        "num_workers": getattr(args, "num_workers", None),
+        "force_rebuild": args.force_rebuild,
+        "sources_max_sources": args.sources_limit,
+        "sources_skip_existing": not args.no_skip_existing,
+    }
+    # Drop None values so experiment defaults apply
+    experiment_options = {k: v for k, v in experiment_options.items() if v is not None}
+
+    run_experiment(experiment_options=experiment_options) 

--- a/run_experiments.py
+++ b/run_experiments.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
 """
-Script to run the ClimateCheck fact-checking experiments with optimized settings.
-This uses the updated embeddings and indexer implementations for efficient processing.
+Script to run fact-checking experiments with optimized settings.
+Pass --experiment <module.path> to run any experiment that exposes a main().
 
 Ollama (LLM and embeddings) is controlled via .env: set LLM_TYPE=ollama,
 EMBEDDING_TYPE=ollama, OLLAMA_API_BASE_URL, OLLAMA_MODEL, etc. in .env.
 """
 
-import os
 import argparse
+import importlib
 import logging
+import os
 import time
 from datetime import datetime
 
@@ -56,40 +57,59 @@ def setup_environment():
             logger.warning(f"Could not connect to Ollama server: {str(e)}")
             logger.warning("Set LLM_TYPE=ollama and EMBEDDING_TYPE=ollama in .env and ensure Ollama is running.")
 
-def run_experiment(experiment_options=None):
-    """Run the advocate-mediator experiment with the specified options.
+DEFAULT_EXPERIMENT = "factchecker.experiments.advocate_mediator_climatefeedback.advocate_mediator_climatefeedback"
 
-    experiment_options overrides EXPERIMENT_PARAMS inside the experiment (sources, indexing, etc.).
-    """
+
+def run_experiment(experiment_module: str, experiment_options=None):
+    """Run an experiment by module path. Options are passed to main() when it accepts them."""
     if experiment_options is None:
         experiment_options = {}
 
-    logger.info("Starting advocate-mediator experiment")
+    logger.info("Starting experiment: %s", experiment_module)
 
     try:
-        from factchecker.experiments.advocate_mediator_climatefeedback.advocate_mediator_climatefeedback import main
-        logger.info("Using advocate-mediator climatefeedback experiment module")
+        mod = importlib.import_module(experiment_module)
+        main = getattr(mod, "main", None)
+        if main is None:
+            logger.error("Module %s has no main() function.", experiment_module)
+            return
 
         start_time = time.time()
-        main(experiment_options=experiment_options)
+        # Prefer passing experiment_options for experiments that support it
+        try:
+            main(experiment_options=experiment_options)
+        except TypeError:
+            try:
+                main(indexer_options=experiment_options)
+            except TypeError:
+                main()
         elapsed = time.time() - start_time
 
-        logger.info(f"Experiment completed successfully in {elapsed//60:.0f}m {elapsed%60:.0f}s")
+        logger.info("Experiment completed successfully in %dm %ds", int(elapsed // 60), int(elapsed % 60))
 
     except ImportError as e:
-        logger.error(f"Could not import the experiment module: {str(e)}")
-        logger.error("Make sure you are in the factchecker directory and have installed the package.")
-        logger.error("Try running: pip install -e .")
+        logger.error("Could not import experiment module: %s", e)
+        logger.error("Use a full module path, e.g. factchecker.experiments.advocate_mediator_climatefeedback.advocate_mediator_climatefeedback")
+        logger.error("Ensure the package is installed: pip install -e .")
 
     except Exception as e:
-        logger.error(f"Error running experiment: {str(e)}")
+        logger.error("Error running experiment: %s", e)
         import traceback
-        logger.error(f"Stack trace: {traceback.format_exc()}")
+        logger.error(traceback.format_exc())
 
 def parse_args():
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(description="Run ClimateCheck fact-checking experiments")
-    
+    parser = argparse.ArgumentParser(
+        description="Run fact-checking experiments. Use --experiment to choose which experiment module to run."
+    )
+    parser.add_argument(
+        "--experiment",
+        type=str,
+        default=DEFAULT_EXPERIMENT,
+        metavar="MODULE",
+        help="Experiment module path (default: %(default)s)",
+    )
+
     parser.add_argument(
         "--node-batch-size", 
         type=int, 
@@ -145,6 +165,15 @@ def parse_args():
         help="Re-download sources even if file already exists"
     )
 
+    # Claim sampling (passed into experiment)
+    parser.add_argument(
+        "--samples",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Number of claims to evaluate (default: use experiment default, e.g. 10)"
+    )
+
     return parser.parse_args()
 
 
@@ -153,7 +182,7 @@ if __name__ == "__main__":
 
     setup_environment()
 
-    # All options passed into experiment; experiment uses EXPERIMENT_PARAMS + these overrides
+    # Options passed into experiment when it accepts experiment_options
     experiment_options = {
         "chunk_size": args.chunk_size,
         "chunk_overlap": args.chunk_overlap,
@@ -163,8 +192,8 @@ if __name__ == "__main__":
         "force_rebuild": args.force_rebuild,
         "sources_max_sources": args.sources_limit,
         "sources_skip_existing": not args.no_skip_existing,
+        "total_samples": getattr(args, "samples", None),
     }
-    # Drop None values so experiment defaults apply
     experiment_options = {k: v for k, v in experiment_options.items() if v is not None}
 
-    run_experiment(experiment_options=experiment_options) 
+    run_experiment(experiment_module=args.experiment, experiment_options=experiment_options) 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+# Deactivate any existing venv
+deactivate 2>/dev/null || true
+
+# Remove existing venv
+rm -rf venv
+
+# Create fresh venv with Python 3.12
+python3.12 -m venv venv
+
+# Activate venv
+source venv/bin/activate
+
+# Upgrade basic packages
+python -m pip install --upgrade pip setuptools wheel
+
+# Install package in editable mode with test dependencies
+python -m pip install -e ".[test]" --verbose --use-pep517
+
+# Run tests with coverage
+export IS_TESTING=true
+export LLAMA_INDEX_EMBED_MODEL=mock
+export MOCK_EMBED_DIM=8
+python -m pytest tests/ --cov=factchecker --cov-report=xml -v 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -7,8 +7,20 @@ deactivate 2>/dev/null || true
 # Remove existing venv
 rm -rf venv
 
-# Create fresh venv with Python 3.12
-python3.12 -m venv venv
+# Prefer Python 3.12, fallback to 3.10
+PYTHON=""
+for p in python3.12 python3.10; do
+  if command -v "$p" &>/dev/null; then
+    PYTHON="$p"
+    break
+  fi
+done
+if [[ -z "$PYTHON" ]]; then
+  echo "Need Python 3.12 or 3.10. Install with e.g. pyenv or your system package manager."
+  exit 1
+fi
+echo "Using $PYTHON for venv"
+"$PYTHON" -m venv venv
 
 # Activate venv
 source venv/bin/activate

--- a/run_with_venv.sh
+++ b/run_with_venv.sh
@@ -1,25 +1,35 @@
 #!/bin/bash
-# Run the advocate-mediator experiment using the project venv and .env for Ollama.
-# Ensure .env has LLM_TYPE=ollama, EMBEDDING_TYPE=ollama, OLLAMA_API_BASE_URL, etc.
+# Run a fact-checking experiment using the project venv and .env (e.g. Ollama).
+# Usage: ./run_with_venv.sh [--experiment MODULE] [options...]
+# Example: ./run_with_venv.sh --experiment factchecker.experiments.ragatouille_colbert_ir
+# Default experiment: advocate-mediator climatefeedback.
 
 set -e
 cd "$(dirname "$0")"
 
-# Use .venv in project root
 VENV_DIR=".venv"
+PYTHON=""
+for p in python3.12 python3.10; do
+  if command -v "$p" &>/dev/null; then
+    PYTHON="$p"
+    break
+  fi
+done
+if [[ -z "$PYTHON" ]]; then
+  echo "Need Python 3.12 or 3.10. Install with e.g. pyenv or your system package manager."
+  exit 1
+fi
 if [[ ! -d "$VENV_DIR" ]]; then
-  echo "Creating venv at $VENV_DIR (Python 3.12)..."
-  python3.12 -m venv "$VENV_DIR"
+  echo "Creating venv at $VENV_DIR ($PYTHON)..."
+  "$PYTHON" -m venv "$VENV_DIR"
 fi
 source "$VENV_DIR/bin/activate"
 
-# Install deps if needed
 if ! python -c "import llama_index" 2>/dev/null; then
   echo "Installing dependencies (pip install -e .)..."
   pip install -e .
 fi
 
-# .env is loaded by the experiment module; copy from example if missing
 if [[ ! -f .env ]]; then
   echo "No .env found. Copy .env.example to .env and set LLM_TYPE=ollama, EMBEDDING_TYPE=ollama for Ollama."
   if [[ -f .env.example ]]; then
@@ -30,5 +40,4 @@ if [[ ! -f .env ]]; then
   exit 1
 fi
 
-echo "Running experiment (Ollama settings from .env)..."
-python -m factchecker.experiments.advocate_mediator_climatefeedback.advocate_mediator_climatefeedback "$@"
+python run_experiments.py "$@"

--- a/run_with_venv.sh
+++ b/run_with_venv.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Run the advocate-mediator experiment using the project venv and .env for Ollama.
+# Ensure .env has LLM_TYPE=ollama, EMBEDDING_TYPE=ollama, OLLAMA_API_BASE_URL, etc.
+
+set -e
+cd "$(dirname "$0")"
+
+# Use .venv in project root
+VENV_DIR=".venv"
+if [[ ! -d "$VENV_DIR" ]]; then
+  echo "Creating venv at $VENV_DIR (Python 3.12)..."
+  python3.12 -m venv "$VENV_DIR"
+fi
+source "$VENV_DIR/bin/activate"
+
+# Install deps if needed
+if ! python -c "import llama_index" 2>/dev/null; then
+  echo "Installing dependencies (pip install -e .)..."
+  pip install -e .
+fi
+
+# .env is loaded by the experiment module; copy from example if missing
+if [[ ! -f .env ]]; then
+  echo "No .env found. Copy .env.example to .env and set LLM_TYPE=ollama, EMBEDDING_TYPE=ollama for Ollama."
+  if [[ -f .env.example ]]; then
+    cp .env.example .env
+    echo "Created .env from .env.example. Edit .env and run again."
+    exit 1
+  fi
+  exit 1
+fi
+
+echo "Running experiment (Ollama settings from .env)..."
+python -m factchecker.experiments.advocate_mediator_climatefeedback.advocate_mediator_climatefeedback "$@"

--- a/scripts/verify_ollama_batch_embed.py
+++ b/scripts/verify_ollama_batch_embed.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""
+Verify Ollama batch embed API: POST /api/embed with input=[text1, text2, ...].
+Run with: python scripts/verify_ollama_batch_embed.py
+Requires: Ollama running (e.g. ollama serve), an embedding model (e.g. ollama pull nomic-embed-text).
+"""
+import json
+import os
+import urllib.error
+import urllib.request
+
+BASE = os.getenv("OLLAMA_API_BASE_URL", "http://localhost:11434")
+MODEL = os.getenv("OLLAMA_EMBEDDING_MODEL") or os.getenv("OLLAMA_MODEL", "nomic-embed-text")
+
+
+def main() -> None:
+    texts = ["first", "second text", "third"]
+    body = json.dumps({"model": MODEL, "input": texts}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{BASE}/api/embed",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read().decode())
+    except urllib.error.URLError as e:
+        print(f"Ollama not reachable at {BASE}: {e}")
+        raise SystemExit(1)
+    except urllib.error.HTTPError as e:
+        print(f"Ollama error: {e.code} {e.reason}")
+        if e.fp:
+            print(e.fp.read().decode())
+        raise SystemExit(1)
+
+    embeddings = data.get("embeddings", [])
+    if len(embeddings) != len(texts):
+        print(f"Expected {len(texts)} embeddings, got {len(embeddings)}")
+        raise SystemExit(1)
+    dim = len(embeddings[0])
+    for i, emb in enumerate(embeddings):
+        if len(emb) != dim:
+            print(f"Embedding {i} length {len(emb)} != {dim}")
+            raise SystemExit(1)
+    print(f"OK: batch embed returned {len(embeddings)} vectors of dimension {dim}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 
 from typing import Generator
 from unittest.mock import MagicMock, patch
@@ -36,8 +37,8 @@ def mock_huggingface() -> Generator[MagicMock, None, None]:
 
 @pytest.fixture
 def mock_ollama() -> Generator[MagicMock, None, None]:
-    """Mock Ollama embedding."""
-    with patch('factchecker.core.embeddings.OllamaEmbedding', autospec=True) as mock:
+    """Mock Ollama batch embedding."""
+    with patch('factchecker.core.embeddings.BatchedOllamaEmbedding', autospec=True) as mock:
         yield mock
 
 class MockEmbedding:

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -16,6 +16,7 @@ def mock_env(monkeypatch: MonkeyPatch) -> MonkeyPatch:
         "OPENAI_API_KEY": None,
         "OPENAI_API_BASE": None,
         "HUGGINGFACE_EMBEDDING_MODEL": None,
+        "OLLAMA_EMBEDDING_MODEL": None,
         "OLLAMA_MODEL": None,
         "OLLAMA_API_BASE_URL": None
     }

--- a/tests/core/test_embeddings.py
+++ b/tests/core/test_embeddings.py
@@ -1,9 +1,10 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pytest import MonkeyPatch
 
 from factchecker.core.embeddings import load_embedding_model
+from factchecker.core.ollama_batch_embedding import BatchedOllamaEmbedding
 
 
 def test_load_openai_embedding_default(mock_env: MonkeyPatch, mock_openai: MagicMock) -> None:
@@ -180,3 +181,71 @@ def test_invalid_embedding_type() -> None:
     """Test error handling for invalid embedding type."""
     with pytest.raises(ValueError, match="Unsupported embedding type: invalid"):
         load_embedding_model(embedding_type="invalid")
+
+
+def test_ollama_batch_uses_embed_api() -> None:
+    """BatchedOllamaEmbedding._get_text_embeddings calls client.embed(input=list), not per-text embeddings()."""
+    mock_client = MagicMock()
+    mock_client.embed.return_value = {"embeddings": [[0.0] * 8, [0.0] * 8]}
+    with patch("llama_index.embeddings.ollama.base.Client", return_value=mock_client), patch(
+        "llama_index.embeddings.ollama.base.AsyncClient", return_value=MagicMock()
+    ):
+        emb = BatchedOllamaEmbedding(
+            model_name="test-model",
+            base_url="http://localhost:11434",
+            embed_batch_size=10,
+        )
+        emb._client = mock_client
+    result = emb._get_text_embeddings(["text one", "text two"])
+    assert len(result) == 2
+    mock_client.embed.assert_called_once()
+    call_kw = mock_client.embed.call_args[1]
+    assert call_kw["input"] == ["text one", "text two"]
+    assert call_kw["model"] == "test-model"
+
+
+def test_ollama_batch_respects_embed_batch_size() -> None:
+    """BatchedOllamaEmbedding chunks by embed_batch_size and calls embed per chunk."""
+    mock_client = MagicMock()
+    # Return 2, 2, 1 vectors for the three chunked calls
+    mock_client.embed.side_effect = [
+        {"embeddings": [[0.0] * 8, [0.0] * 8]},
+        {"embeddings": [[0.0] * 8, [0.0] * 8]},
+        {"embeddings": [[0.0] * 8]},
+    ]
+    with patch("llama_index.embeddings.ollama.base.Client", return_value=mock_client), patch(
+        "llama_index.embeddings.ollama.base.AsyncClient", return_value=MagicMock()
+    ):
+        emb = BatchedOllamaEmbedding(
+            model_name="m",
+            base_url="http://localhost:11434",
+            embed_batch_size=2,
+        )
+        emb._client = mock_client
+    # 5 texts, batch_size=2 -> 3 calls: [0:2], [2:4], [4:5]
+    result = emb._get_text_embeddings(["a", "b", "c", "d", "e"])
+    assert len(result) == 5
+    assert mock_client.embed.call_count == 3
+    calls = [c[1]["input"] for c in mock_client.embed.call_args_list]
+    assert calls == [["a", "b"], ["c", "d"], ["e"]]
+
+
+def test_ollama_batch_returns_correct_shape() -> None:
+    """BatchedOllamaEmbedding returns one vector per input text."""
+    dim = 8
+    mock_client = MagicMock()
+    mock_client.embed.return_value = {
+        "embeddings": [[0.1] * dim, [0.2] * dim],
+    }
+    with patch("llama_index.embeddings.ollama.base.Client", return_value=mock_client), patch(
+        "llama_index.embeddings.ollama.base.AsyncClient", return_value=MagicMock()
+    ):
+        emb = BatchedOllamaEmbedding(
+            model_name="m",
+            base_url="http://localhost:11434",
+        )
+        emb._client = mock_client
+    result = emb._get_text_embeddings(["a", "b"])
+    assert len(result) == 2
+    assert len(result[0]) == dim and len(result[1]) == dim
+    assert result[0][0] == 0.1 and result[1][0] == 0.2

--- a/tests/core/test_embeddings.py
+++ b/tests/core/test_embeddings.py
@@ -133,7 +133,7 @@ def test_load_ollama_embedding(mock_env: MonkeyPatch, mock_ollama: MagicMock) ->
     )
 
 def test_load_ollama_embedding_from_env(mock_env: MonkeyPatch, mock_ollama: MagicMock) -> None:
-    """Test loading Ollama embedding."""
+    """Test loading Ollama embedding from env (OLLAMA_MODEL)."""
     mock_env.setenv("EMBEDDING_TYPE", "ollama")
     mock_env.setenv("OLLAMA_MODEL", "nomic-embed-text")
     mock_env.setenv("OLLAMA_API_BASE_URL", "http://localhost:11434")
@@ -142,6 +142,21 @@ def test_load_ollama_embedding_from_env(mock_env: MonkeyPatch, mock_ollama: Magi
     
     mock_ollama.assert_called_once_with(
         model_name="nomic-embed-text",
+        base_url="http://localhost:11434"
+    )
+
+
+def test_load_ollama_embedding_uses_embedding_model_env(mock_env: MonkeyPatch, mock_ollama: MagicMock) -> None:
+    """When OLLAMA_EMBEDDING_MODEL is set, it is used for embeddings (overrides OLLAMA_MODEL)."""
+    mock_env.setenv("EMBEDDING_TYPE", "ollama")
+    mock_env.setenv("OLLAMA_EMBEDDING_MODEL", "jina/jina-embeddings-v2-base-de")
+    mock_env.setenv("OLLAMA_MODEL", "llama3.2:latest")
+    mock_env.setenv("OLLAMA_API_BASE_URL", "http://localhost:11434")
+    
+    _ = load_embedding_model()
+    
+    mock_ollama.assert_called_once_with(
+        model_name="jina/jina-embeddings-v2-base-de",
         base_url="http://localhost:11434"
     )
 
@@ -249,3 +264,33 @@ def test_ollama_batch_returns_correct_shape() -> None:
     assert len(result) == 2
     assert len(result[0]) == dim and len(result[1]) == dim
     assert result[0][0] == 0.1 and result[1][0] == 0.2
+
+
+@pytest.mark.integration
+def test_ollama_batch_real_local() -> None:
+    """
+    Real Ollama test: load BatchedOllamaEmbedding via load_embedding_model(embedding_type="ollama")
+    and get embeddings for multiple texts. Skips if Ollama is not reachable or no embedding model.
+    Uses OLLAMA_API_BASE_URL from env (default http://localhost:11434).
+    """
+    import os
+    import urllib.error
+    import urllib.request
+
+    base_url = os.getenv("OLLAMA_API_BASE_URL", "http://localhost:11434")
+    try:
+        urllib.request.urlopen(f"{base_url.rstrip('/')}/api/tags", timeout=5)
+    except (OSError, urllib.error.URLError) as err:
+        pytest.skip(f"Ollama not reachable at {base_url}: {err}")
+
+    model = load_embedding_model(embedding_type="ollama")
+    assert isinstance(model, BatchedOllamaEmbedding)
+
+    texts = ["first", "second text", "third"]
+    embeddings = model.get_text_embedding_batch(texts)
+    assert len(embeddings) == len(texts)
+    dim = len(embeddings[0])
+    assert dim > 0
+    for i, emb in enumerate(embeddings):
+        assert len(emb) == dim, f"embedding {i} wrong length"
+        assert all(isinstance(x, float) for x in emb), f"embedding {i} not all float"

--- a/tests/indexing/test_abstract_indexer.py
+++ b/tests/indexing/test_abstract_indexer.py
@@ -1,0 +1,102 @@
+"""Tests for AbstractIndexer.initialize_index load/save persistence behavior."""
+import os
+from typing import Any, Dict, List, Optional
+from unittest.mock import patch
+
+import pytest
+from llama_index.core import Document
+
+from factchecker.indexing.abstract_indexer import AbstractIndexer
+
+
+class MinimalConcreteIndexer(AbstractIndexer):
+    """Minimal concrete indexer to test AbstractIndexer.initialize_index behavior."""
+
+    def __init__(self, options: Optional[Dict[str, Any]] = None, *, calls: Optional[Dict[str, int]] = None):
+        super().__init__(options)
+        self.calls = calls if calls is not None else {}
+
+    def build_index(self, documents: List[Document]) -> None:
+        self.calls["build_index"] = self.calls.get("build_index", 0) + 1
+        self.index = "built"
+
+    def save_index(self, index_path: Optional[str] = None) -> None:
+        self.calls["save_index"] = self.calls.get("save_index", 0) + 1
+
+    def load_index(self) -> None:
+        self.calls["load_index"] = self.calls.get("load_index", 0) + 1
+        self.index = "loaded"
+
+    def add_to_index(self, documents: List[Any]) -> None:
+        raise NotImplementedError
+
+    def delete_from_index(self, document_ids: List[Any]) -> None:
+        raise NotImplementedError
+
+
+def test_initialize_index_loads_when_index_path_exists(tmp_path):
+    """When index_path is set and path exists, initialize_index calls load_index (no build/save)."""
+    (tmp_path / "some_file").write_text("x")
+    calls = {}
+    indexer = MinimalConcreteIndexer(
+        {"index_path": str(tmp_path), "documents": [Document(text="d")]},
+        calls=calls,
+    )
+    with patch.object(MinimalConcreteIndexer, "check_persisted_index_exists", return_value=True):
+        indexer.initialize_index()
+    assert indexer.index == "loaded"
+    assert calls.get("load_index") == 1
+    assert calls.get("build_index", 0) == 0
+    assert calls.get("save_index", 0) == 0
+
+
+def test_initialize_index_builds_and_saves_when_index_path_set_but_not_exists(tmp_path):
+    """When index_path is set but path does not exist, initialize_index builds then saves."""
+    index_path = tmp_path / "missing"
+    assert not index_path.exists()
+    calls = {}
+    indexer = MinimalConcreteIndexer(
+        {"index_path": str(index_path), "documents": [Document(text="d")]},
+        calls=calls,
+    )
+    indexer.initialize_index()
+    assert indexer.index == "built"
+    assert calls.get("build_index") == 1
+    assert calls.get("save_index") == 1
+    assert calls.get("load_index", 0) == 0
+
+
+def test_initialize_index_build_only_when_no_index_path(tmp_path):
+    """When index_path is not set, initialize_index only builds (no load, no save)."""
+    calls = {}
+    indexer = MinimalConcreteIndexer(
+        {"documents": [Document(text="d")]},
+        calls=calls,
+    )
+    indexer.initialize_index()
+    assert indexer.index == "built"
+    assert calls.get("build_index") == 1
+    assert calls.get("save_index", 0) == 0
+    assert calls.get("load_index", 0) == 0
+
+
+def test_initialize_index_skips_when_index_already_set():
+    """When index is already set, initialize_index does nothing."""
+    calls = {}
+    indexer = MinimalConcreteIndexer({"documents": [Document(text="d")]}, calls=calls)
+    indexer.index = "already_there"
+    indexer.initialize_index()
+    assert indexer.index == "already_there"
+    assert calls.get("build_index", 0) == 0
+    assert calls.get("save_index", 0) == 0
+    assert calls.get("load_index", 0) == 0
+
+
+def test_check_persisted_index_exists(tmp_path):
+    """check_persisted_index_exists returns True only when index_path exists."""
+    indexer = MinimalConcreteIndexer({})
+    assert indexer.check_persisted_index_exists() is False
+    indexer.index_path = "/nonexistent/path"
+    assert indexer.check_persisted_index_exists() is False
+    indexer.index_path = str(tmp_path)
+    assert indexer.check_persisted_index_exists() is True

--- a/tests/information_retrieval/indexing/test_llama_vector_store_indexer.py
+++ b/tests/information_retrieval/indexing/test_llama_vector_store_indexer.py
@@ -1,7 +1,10 @@
 """Tests for the LlamaVectorStoreIndexer class."""
 
+import os
+
 import pytest
 from llama_index.core import Document
+from unittest.mock import patch
 
 from factchecker.indexing.llama_vector_store_indexer import LlamaVectorStoreIndexer
 
@@ -35,3 +38,52 @@ def test_initialize_index_from_directory(get_test_data_directory: str) -> None:
     indexer.initialize_index()
     assert indexer.index is not None
     assert indexer.index_name == 'test_index_from_dir'
+
+
+# --- save_index / load_index (TDD) ---
+@pytest.mark.integration
+def test_save_index_persists_to_disk(get_test_documents: list[Document], tmp_path) -> None:
+    """Build index, call save_index, assert index_path contains expected files."""
+    index_path = str(tmp_path / "index")
+    with patch.dict('os.environ', {'EMBEDDING_TYPE': 'mock', 'MOCK_EMBED_DIM': '384'}):
+        indexer_options = {
+            'documents': get_test_documents,
+            'index_name': 'test_save',
+            'index_path': index_path,
+            'transformations': [],
+        }
+        indexer = LlamaVectorStoreIndexer(indexer_options)
+        indexer.build_index(get_test_documents)
+        indexer.save_index()
+    assert os.path.isdir(index_path)
+    # LlamaIndex persists docstore, index_store, vector store, graph store
+    assert os.path.isfile(os.path.join(index_path, 'docstore.json')) or os.path.exists(
+        os.path.join(index_path, 'default__vector_store.json')
+    )
+
+
+@pytest.mark.integration
+def test_load_index_restores(get_test_documents: list[Document], tmp_path) -> None:
+    """Build and save; create new indexer, load_index; assert index is usable (retriever returns nodes)."""
+    index_path = str(tmp_path / "index")
+    with patch.dict('os.environ', {'EMBEDDING_TYPE': 'mock', 'MOCK_EMBED_DIM': '384'}):
+        indexer_options = {
+            'documents': get_test_documents,
+            'index_name': 'test_load',
+            'index_path': index_path,
+            'transformations': [],
+        }
+        indexer = LlamaVectorStoreIndexer(indexer_options)
+        indexer.build_index(get_test_documents)
+        indexer.save_index()
+    # Load in a new indexer (same index_path, no documents)
+    with patch.dict('os.environ', {'EMBEDDING_TYPE': 'mock', 'MOCK_EMBED_DIM': '384'}):
+        indexer2 = LlamaVectorStoreIndexer({
+            'index_name': 'test_load',
+            'index_path': index_path,
+        })
+        indexer2.load_index()
+    assert indexer2.index is not None
+    retriever = indexer2.index.as_retriever(similarity_top_k=2)
+    nodes = retriever.retrieve("first document")
+    assert len(nodes) >= 1

--- a/tests/steps/test_advocate.py
+++ b/tests/steps/test_advocate.py
@@ -5,7 +5,7 @@ from llama_index.core.schema import NodeWithScore, TextNode
 
 from factchecker.indexing.abstract_indexer import AbstractIndexer
 from factchecker.retrieval.abstract_retriever import AbstractRetriever
-from factchecker.steps.advocate import AdvocateStep
+from factchecker.steps.advocate import ADVOCATE_VERDICT_FORMAT, AdvocateStep
 
 
 @pytest.fixture
@@ -119,4 +119,43 @@ def test_retry_mechanism(mock_llm: MagicMock, mock_retriever: MagicMock) -> None
     
     verdict, reasoning = advocate.evaluate_claim("Test claim")
     assert verdict == "CORRECT"
-    assert mock_llm.chat.call_count == 3 
+    assert mock_llm.chat.call_count == 3
+
+
+def test_advocate_retry_includes_format_feedback(mock_llm: MagicMock, mock_retriever: MagicMock) -> None:
+    """On retry after wrong format, second chat call receives messages with last answer and format instruction."""
+    wrong = '{ "verdict": ("correct", "medium") }'
+    right = "Reasoning here. ((correct))"
+    mock_llm.chat.side_effect = [
+        MagicMock(message=MagicMock(content=wrong)),
+        MagicMock(message=MagicMock(content=right)),
+    ]
+    advocate = AdvocateStep(retriever=mock_retriever, llm=mock_llm)
+    verdict, _ = advocate.evaluate_claim("Test claim")
+    assert verdict == "CORRECT"
+    assert mock_llm.chat.call_count == 2
+    messages_second = mock_llm.chat.call_args[0][0]
+    retry_user = next(m for m in messages_second if m.role == "user" and "wrong format" in m.content)
+    assert "Your previous response was in the wrong format" in retry_user.content
+    assert "This was your last answer" in retry_user.content
+    assert ADVOCATE_VERDICT_FORMAT in retry_user.content or "((correct))" in retry_user.content
+
+
+def test_advocate_custom_verdict_parser(mock_llm: MagicMock, mock_retriever: MagicMock) -> None:
+    """When verdict_parser is provided, it is used and can parse alternative formats."""
+    def parse_json_style(content):
+        if '"verdict":' in content and "correct" in content.lower():
+            return ("CORRECT", "Parsed from JSON-style response.")
+        return None
+    mock_llm.chat.return_value = MagicMock(
+        message=MagicMock(content='{ "verdict": ("correct", "medium") }\nReasoning here.')
+    )
+    advocate = AdvocateStep(
+        retriever=mock_retriever,
+        llm=mock_llm,
+        options={"verdict_parser": parse_json_style},
+    )
+    verdict, reasoning = advocate.evaluate_claim("Test claim")
+    assert verdict == "CORRECT"
+    assert "Parsed from JSON-style" in reasoning
+    assert mock_llm.chat.call_count == 1 

--- a/tests/steps/test_mediator.py
+++ b/tests/steps/test_mediator.py
@@ -1,7 +1,8 @@
 import pytest
 from unittest.mock import Mock, MagicMock, patch
-from factchecker.steps.mediator import MediatorStep
 from llama_index.core.llms import ChatMessage
+
+from factchecker.steps.mediator import MediatorStep, MEDIATOR_VERDICT_FORMAT
 
 @pytest.fixture
 def mock_llm():
@@ -73,4 +74,49 @@ def test_empty_verdicts(mock_llm):
     result = mediator.synthesize_verdicts([], "Test claim")
     
     # The actual implementation returns the LLM response even for empty verdicts
-    assert result == "CORRECT" 
+    assert result == "CORRECT"
+
+
+def test_mediator_retry_includes_format_feedback(mock_llm):
+    """On retry after wrong format, second chat call receives messages with last answer and format instruction."""
+    wrong = '{ "verdict": ("correct", "medium") }'
+    right = "((correct))"
+    mock_llm.chat.side_effect = [
+        MagicMock(message=MagicMock(content=wrong)),
+        MagicMock(message=MagicMock(content=right)),
+    ]
+    mediator = MediatorStep(llm=mock_llm)
+    result = mediator.synthesize_verdicts([("CORRECT", "r1")], "Claim")
+    assert result == "CORRECT"
+    assert mock_llm.chat.call_count == 2
+    # Second call: messages include assistant (wrong) + user retry with format feedback
+    messages_second = mock_llm.chat.call_args[0][0]
+    assert len(messages_second) >= 4
+    retry_user = next(m for m in messages_second if m.role == "user" and "wrong format" in m.content)
+    assert "Your previous response was in the wrong format" in retry_user.content
+    assert "This was your last answer" in retry_user.content
+    assert "wrong" in retry_user.content.lower()
+    assert MEDIATOR_VERDICT_FORMAT in retry_user.content or "((correct))" in retry_user.content
+
+
+def test_mediator_custom_verdict_parser(mock_llm):
+    """When verdict_parser is provided, it is used and can parse alternative formats."""
+    def parse_json_style(content):
+        if '"verdict":' in content and "correct" in content.lower():
+            return "CORRECT"
+        if '"verdict":' in content and "incorrect" in content.lower():
+            return "INCORRECT"
+        return None
+    mock_llm.chat.return_value = MagicMock(
+        message=MagicMock(content='{ "verdict": ("correct", "medium") }\nSome reasoning.')
+    )
+    mediator = MediatorStep(llm=mock_llm, options={"verdict_parser": parse_json_style})
+    result = mediator.synthesize_verdicts([("CORRECT", "r1")], "Claim")
+    assert result == "CORRECT"
+    assert mock_llm.chat.call_count == 1
+
+
+def test_mediator_max_retries_from_options(mock_llm):
+    """max_retries can be overridden via options."""
+    mediator = MediatorStep(llm=mock_llm, options={"max_retries": 5})
+    assert mediator.max_retries == 5 

--- a/tests/steps/test_verdict_retry.py
+++ b/tests/steps/test_verdict_retry.py
@@ -1,0 +1,63 @@
+"""Tests for the shared verdict retry helper (no LLM/ollama imports)."""
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from llama_index.core.llms import ChatMessage
+
+from factchecker.steps.verdict_retry import chat_with_verdict_retry
+
+
+def test_parsed_on_first_try_returns_result():
+    """First response parses; no retry."""
+    messages = [ChatMessage(role="user", content="Hi")]
+    llm = MagicMock()
+    llm.chat.return_value = MagicMock(message=MagicMock(content="((correct))"))
+    parse = lambda s: "CORRECT" if "((" in s and "))" in s else None
+    logger = logging.getLogger("test")
+    result = chat_with_verdict_retry(
+        messages, llm, parse, "Use ((...))", 3, {}, logger
+    )
+    assert result == "CORRECT"
+    assert llm.chat.call_count == 1
+
+
+def test_retry_appends_format_feedback_then_succeeds():
+    """First response unparseable; retry message includes format instruction; second parses."""
+    messages = [ChatMessage(role="user", content="Hi")]
+    llm = MagicMock()
+    llm.chat.side_effect = [
+        MagicMock(message=MagicMock(content="invalid")),
+        MagicMock(message=MagicMock(content="((incorrect))")),
+    ]
+    def parse(s):
+        if "((" not in s or "))" not in s:
+            return None
+        start, end = s.find("((") + 2, s.find("))")
+        return s[start:end].strip().upper().replace(" ", "_")
+    format_instruction = "Use ((correct)) or ((incorrect))"
+    logger = logging.getLogger("test")
+    result = chat_with_verdict_retry(
+        messages, llm, parse, format_instruction, 2, {}, logger
+    )
+    assert result == "INCORRECT"
+    assert llm.chat.call_count == 2
+    second_messages = llm.chat.call_args[0][0]
+    retry_user = next(m for m in second_messages if m.role == "user" and "wrong format" in m.content)
+    assert "Your previous response was in the wrong format" in retry_user.content
+    assert "invalid" in retry_user.content
+    assert format_instruction in retry_user.content
+
+
+def test_all_retries_fail_returns_none():
+    """All attempts unparseable; returns None."""
+    messages = [ChatMessage(role="user", content="Hi")]
+    llm = MagicMock()
+    llm.chat.return_value = MagicMock(message=MagicMock(content="nope"))
+    parse = lambda s: None
+    logger = logging.getLogger("test")
+    result = chat_with_verdict_retry(
+        messages, llm, parse, "Format", 2, {}, logger
+    )
+    assert result is None
+    assert llm.chat.call_count == 2

--- a/tests/tools/test_sources_downloader.py
+++ b/tests/tools/test_sources_downloader.py
@@ -57,21 +57,24 @@ def test_output_folder_exists():
         output_folder='test_data',
         row_indices=None,
         url_column='external_link',
-        output_filename_column='output_filename',
-        output_subfolder_column='output_subfolder'
+        output_filename_column='pdf_title',
+        output_subfolder_column='output_subfolder',
+        limit=None,
+        no_skip_existing=False,
     )
-    
+
     # Patch argparse to return our mock arguments.
     with patch('gettext.translation'), \
          patch('argparse.ArgumentParser.parse_args', return_value=mock_args), \
          patch('os.path.exists', return_value=True), \
          patch('os.makedirs') as mock_makedirs, \
          patch('factchecker.tools.sources_downloader.SourcesDownloader.download_pdfs_from_csv') as mock_download:
-            
+
         SourcesDownloader.run_cli()
         mock_makedirs.assert_not_called()
         mock_download.assert_called_once_with(
-            'test.csv', None, 'external_link', 'output_filename', 'output_subfolder'
+            'test.csv', None, 'external_link', 'pdf_title', 'output_subfolder',
+            skip_existing=True, max_sources=None
         )
 
 
@@ -81,5 +84,117 @@ def test_cli_arguments():
     with patch('sys.argv', testargs):
         with patch('factchecker.tools.sources_downloader.SourcesDownloader.download_pdfs_from_csv') as mock_download:
             SourcesDownloader.run_cli()
-            # The row_indices parameter should now be parsed as [1, 2]
-            mock_download.assert_called_once_with('test.csv', [1, 2], 'test_url', 'output_filename', 'output_subfolder')
+            # The row_indices parameter should now be parsed as [1, 2]; defaults include pdf_title, skip_existing, max_sources
+            mock_download.assert_called_once_with(
+                'test.csv', [1, 2], 'test_url', 'pdf_title', 'output_subfolder',
+                skip_existing=True, max_sources=None
+            )
+
+
+# --- Skip existing files (TDD) ---
+def test_skip_existing_file(tmp_path):
+    """When file already exists and skip_existing=True, download_pdf is not called."""
+    csv_path = tmp_path / "sources.csv"
+    csv_path.write_text("url,output_filename\nhttp://example.com/a.pdf,existing.pdf")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    existing_pdf = out_dir / "existing.pdf"
+    existing_pdf.write_bytes(b"existing content")
+
+    downloader = SourcesDownloader(str(out_dir))
+    with patch.object(downloader, 'download_pdf') as mock_download:
+        result = downloader.download_pdfs_from_csv(
+            str(csv_path),
+            url_column="url",
+            output_filename_column="output_filename",
+            skip_existing=True,
+        )
+    mock_download.assert_not_called()
+    assert result == [str(existing_pdf)]
+
+
+def test_download_when_file_missing(tmp_path):
+    """When file does not exist, download_pdf is called."""
+    csv_path = tmp_path / "sources.csv"
+    csv_path.write_text("url,output_filename\nhttp://example.com/a.pdf,missing.pdf")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    downloader = SourcesDownloader(str(out_dir))
+    with patch.object(downloader, 'download_pdf', return_value=True) as mock_download:
+        downloader.download_pdfs_from_csv(
+            str(csv_path),
+            url_column="url",
+            output_filename_column="output_filename",
+            skip_existing=True,
+        )
+    mock_download.assert_called_once()
+    call_args = mock_download.call_args[0]
+    assert call_args[2] == "missing.pdf"
+
+
+def test_skip_existing_false(tmp_path):
+    """When skip_existing=False, download is attempted even if file exists."""
+    csv_path = tmp_path / "sources.csv"
+    csv_path.write_text("url,output_filename\nhttp://example.com/a.pdf,existing.pdf")
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    (out_dir / "existing.pdf").write_bytes(b"old")
+
+    downloader = SourcesDownloader(str(out_dir))
+    with patch.object(downloader, 'download_pdf', return_value=True) as mock_download:
+        downloader.download_pdfs_from_csv(
+            str(csv_path),
+            url_column="url",
+            output_filename_column="output_filename",
+            skip_existing=False,
+        )
+    mock_download.assert_called_once()
+
+
+# --- max_sources (TDD) ---
+def test_max_sources_limits_downloads(tmp_path):
+    """With max_sources=2, at most 2 downloads are attempted."""
+    csv_path = tmp_path / "sources.csv"
+    csv_path.write_text(
+        "url,output_filename\n"
+        "http://a.com/1.pdf,one.pdf\n"
+        "http://a.com/2.pdf,two.pdf\n"
+        "http://a.com/3.pdf,three.pdf\n"
+    )
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    downloader = SourcesDownloader(str(out_dir))
+    with patch.object(downloader, 'download_pdf', return_value=True) as mock_download:
+        result = downloader.download_pdfs_from_csv(
+            str(csv_path),
+            url_column="url",
+            output_filename_column="output_filename",
+            max_sources=2,
+        )
+    assert mock_download.call_count == 2
+    assert len(result) == 2
+
+
+def test_max_sources_none(tmp_path):
+    """With max_sources=None, all rows are processed."""
+    csv_path = tmp_path / "sources.csv"
+    csv_path.write_text(
+        "url,output_filename\n"
+        "http://a.com/1.pdf,one.pdf\n"
+        "http://a.com/2.pdf,two.pdf\n"
+    )
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    downloader = SourcesDownloader(str(out_dir))
+    with patch.object(downloader, 'download_pdf', return_value=True) as mock_download:
+        result = downloader.download_pdfs_from_csv(
+            str(csv_path),
+            url_column="url",
+            output_filename_column="output_filename",
+            max_sources=None,
+        )
+    assert mock_download.call_count == 2
+    assert len(result) == 2

--- a/tests/utils/test_climatefeedback_utils.py
+++ b/tests/utils/test_climatefeedback_utils.py
@@ -1,5 +1,11 @@
+import pandas as pd
 import pytest
-from factchecker.utils.climatefeedback_utils import map_verdict, VALID_LEVELS
+
+from factchecker.utils.climatefeedback_utils import (
+    evaluate_climatefeedback_claims,
+    map_verdict,
+    VALID_LEVELS,
+)
 
 def test_map_verdict_level_7():
     # Test level 7 mapping (most granular)
@@ -72,4 +78,91 @@ def test_map_verdict_invalid_level():
     with pytest.raises(ValueError, match=f"Level must be one of {VALID_LEVELS}"):
         map_verdict("correct", level=6)
     with pytest.raises(ValueError, match=f"Level must be one of {VALID_LEVELS}"):
-        map_verdict("correct", level=0) 
+        map_verdict("correct", level=0)
+
+
+# --- evaluate_climatefeedback_claims: return (collectors, errors), error tracking, claim_indices ---
+
+
+def test_evaluate_climatefeedback_claims_returns_collectors_and_errors():
+    """evaluate_climatefeedback_claims returns (collectors, errors); no errors when all succeed."""
+    strategy = _make_mock_strategy(
+        [
+            ("correct", ["SUPPORTS"], ["r1"]),
+            ("incorrect", ["REFUTES"], ["r2"]),
+        ]
+    )
+    claims_df = pd.DataFrame({
+        "Claim": ["First claim.", "Second claim."],
+        "Climate Feedback": ["correct", "incorrect"],
+    })
+    collectors, errors = evaluate_climatefeedback_claims(strategy, claims_df, num_advocates=1)
+    assert isinstance(collectors, dict)
+    assert isinstance(errors, list)
+    assert len(errors) == 0
+    assert len(collectors["true_labels"]) == 2
+    assert "claim_indices" in collectors
+    assert len(collectors["claim_indices"]) == 2
+
+
+def test_evaluate_climatefeedback_claims_tracks_errors_on_failure():
+    """When strategy raises on some claims, errors list is populated and collectors only have successes."""
+    strategy = _make_mock_strategy(
+        [
+            ("correct", ["SUPPORTS"], ["r1"]),
+            None,  # second call raises
+            ("correct", ["SUPPORTS"], ["r3"]),
+        ],
+        raise_on_none=True,
+    )
+    claims_df = pd.DataFrame({
+        "Claim": ["Claim one.", "Claim two fail.", "Claim three."],
+        "Climate Feedback": ["correct", "incorrect", "correct"],
+    })
+    collectors, errors = evaluate_climatefeedback_claims(strategy, claims_df, num_advocates=1)
+    assert len(collectors["true_labels"]) == 2
+    assert len(errors) == 1
+    assert errors[0]["error_type"] == "ValueError"
+    assert "Intentional failure" in errors[0]["error_message"]
+    assert errors[0]["claim_index"] == 1
+    assert "Claim two" in errors[0]["claim_preview"]
+
+
+def test_evaluate_climatefeedback_claims_claim_indices_only_successes():
+    """claim_indices contains only indices of successfully evaluated claims."""
+    strategy = _make_mock_strategy(
+        [
+            ("correct", ["SUPPORTS"], ["r1"]),
+            None,  # raise on index 1
+            ("incorrect", ["REFUTES"], ["r3"]),
+        ],
+        raise_on_none=True,
+    )
+    claims_df = pd.DataFrame({
+        "Claim": ["A", "B", "C"],
+        "Climate Feedback": ["correct", "incorrect", "incorrect"],
+    })
+    collectors, errors = evaluate_climatefeedback_claims(strategy, claims_df, num_advocates=1)
+    # Indices from iterrows() are 0, 1, 2 (default RangeIndex)
+    assert collectors["claim_indices"] == [0, 2]
+    assert len(errors) == 1 and errors[0]["claim_index"] == 1
+
+
+def _make_mock_strategy(returns, raise_on_none=False):
+    """Strategy whose evaluate_claim returns the next item from returns; None means raise if raise_on_none."""
+
+    class MockStrategy:
+        def __init__(self):
+            self.returns = returns
+            self.raise_on_none = raise_on_none
+            self.call_count = 0
+
+        def evaluate_claim(self, claim):
+            i = self.call_count
+            self.call_count += 1
+            val = self.returns[i] if i < len(self.returns) else self.returns[-1]
+            if val is None and self.raise_on_none:
+                raise ValueError("Intentional failure for testing")
+            return val
+
+    return MockStrategy() 

--- a/tests/utils/test_experiment_utils.py
+++ b/tests/utils/test_experiment_utils.py
@@ -1,0 +1,153 @@
+"""Tests for experiment_utils: show_evaluation_errors, save_evaluation_errors, create_results_dataframe (partial results)."""
+import os
+import pandas as pd
+import pytest
+
+from factchecker.utils.experiment_utils import (
+    create_results_dataframe,
+    initialize_results_collectors,
+    save_evaluation_errors,
+    show_evaluation_errors,
+)
+
+
+def test_show_evaluation_errors_empty(capfd):
+    """Empty errors list should print nothing."""
+    show_evaluation_errors([])
+    out, _ = capfd.readouterr()
+    assert "Evaluation errors" not in out
+    assert out.strip() == ""
+
+
+def test_show_evaluation_errors_prints_summary_and_details(capfd):
+    """Errors are printed: summary (count, by type) and per-error details."""
+    errors = [
+        {
+            "claim_index": 0,
+            "error_type": "ValueError",
+            "error_message": "Parse failed",
+            "claim_preview": "Some claim text...",
+        },
+        {
+            "claim_index": 2,
+            "error_type": "TimeoutError",
+            "error_message": "Took too long",
+            "claim_preview": "Another claim...",
+        },
+    ]
+    show_evaluation_errors(errors, total_claims=5)
+    out, _ = capfd.readouterr()
+    assert "--- Evaluation errors ---" in out
+    assert "Failed claims: 2 / 5" in out
+    assert "By error type:" in out
+    assert "ValueError" in out
+    assert "TimeoutError" in out
+    assert "Details:" in out
+    assert "[0] ValueError: Parse failed" in out
+    assert "Some claim text" in out
+    assert "[2] TimeoutError: Took too long" in out
+    assert "---" in out
+
+
+def test_show_evaluation_errors_no_total_claims(capfd):
+    """total_claims can be omitted (shows '?' for total)."""
+    show_evaluation_errors([{"claim_index": 0, "error_type": "X", "error_message": "m"}], total_claims=None)
+    out, _ = capfd.readouterr()
+    assert "Failed claims: 1 / ?" in out
+
+
+def test_create_results_dataframe_partial_claims_claim_indices():
+    """When claim_indices is set, results DataFrame contains only those claims (partial results)."""
+    claims = pd.DataFrame({
+        "Claim": ["claim A", "claim B", "claim C"],
+        "Climate Feedback": ["correct", "incorrect", "correct"],
+    })
+    # Simulate: only claims at index 0 and 2 were successfully evaluated
+    collectors = initialize_results_collectors(1)
+    collectors["true_labels"] = ["correct", "correct"]
+    collectors["predicted_results"] = ["correct", "incorrect"]
+    collectors["mediator_reasonings"] = ["r1", "r2"]
+    collectors["advocate_evidences"] = [["e1", "e2"]]
+    collectors["advocate_verdicts"] = [["v1", "v2"]]
+    collectors["advocate_reasonings"] = [["x1", "x2"]]
+    collectors["claim_indices"] = [0, 2]
+
+    result = create_results_dataframe(claims, collectors)
+
+    assert len(result) == 2
+    assert list(result["Claim"].values) == ["claim A", "claim C"]
+    assert list(result["True Label"].values) == ["correct", "correct"]
+
+
+def test_create_results_dataframe_full_claims_no_claim_indices():
+    """Without claim_indices, full length must match (classic behavior)."""
+    claims = pd.DataFrame({
+        "Claim": ["claim A", "claim B"],
+        "Climate Feedback": ["correct", "incorrect"],
+    })
+    collectors = initialize_results_collectors(1)
+    collectors["true_labels"] = ["correct", "incorrect"]
+    collectors["predicted_results"] = ["correct", "incorrect"]
+    collectors["mediator_reasonings"] = ["r1", "r2"]
+    collectors["advocate_evidences"] = [["e1", "e2"]]
+    collectors["advocate_verdicts"] = [["v1", "v2"]]
+    collectors["advocate_reasonings"] = [["x1", "x2"]]
+    # no claim_indices
+
+    result = create_results_dataframe(claims, collectors)
+
+    assert len(result) == 2
+    assert list(result["Claim"].values) == ["claim A", "claim B"]
+
+
+def test_create_results_dataframe_length_mismatch_raises():
+    """When not using claim_indices, length mismatch raises ValueError."""
+    claims = pd.DataFrame({"Claim": ["a", "b"], "Climate Feedback": ["c", "i"]})
+    collectors = initialize_results_collectors(1)
+    collectors["true_labels"] = ["correct", "incorrect", "correct"]  # 3
+    collectors["predicted_results"] = ["c", "i", "c"]
+    collectors["mediator_reasonings"] = ["r1", "r2", "r3"]
+    collectors["advocate_evidences"] = [["e1", "e2", "e3"]]
+    collectors["advocate_verdicts"] = [["v1", "v2", "v3"]]
+    collectors["advocate_reasonings"] = [["x1", "x2", "x3"]]
+
+    with pytest.raises(ValueError, match="Number of claims doesn't match"):
+        create_results_dataframe(claims, collectors)
+
+
+def test_create_results_dataframe_claim_indices_length_mismatch_raises():
+    """claim_indices length must match collected results length."""
+    claims = pd.DataFrame({"Claim": ["a", "b", "c"], "Climate Feedback": ["c", "i", "c"]})
+    collectors = initialize_results_collectors(1)
+    collectors["true_labels"] = ["correct", "correct"]
+    collectors["predicted_results"] = ["c", "c"]
+    collectors["mediator_reasonings"] = ["r1", "r2"]
+    collectors["advocate_evidences"] = [["e1", "e2"]]
+    collectors["advocate_verdicts"] = [["v1", "v2"]]
+    collectors["advocate_reasonings"] = [["x1", "x2"]]
+    collectors["claim_indices"] = [0, 2, 1]  # 3 indices but only 2 results
+
+    with pytest.raises(ValueError, match="claim_indices length must match"):
+        create_results_dataframe(claims, collectors)
+
+
+def test_save_evaluation_errors_empty_returns_none(tmp_path):
+    """Empty errors list returns None and does not write a file."""
+    path = save_evaluation_errors([], base_path=str(tmp_path))
+    assert path is None
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_save_evaluation_errors_writes_csv(tmp_path):
+    """Errors are written to a timestamped CSV; returns path."""
+    errors = [
+        {"claim_index": 0, "error_type": "ValueError", "error_message": "Bad", "claim_preview": "x"},
+    ]
+    path = save_evaluation_errors(errors, base_path=str(tmp_path), prefix="err")
+    assert path is not None
+    assert os.path.basename(path).startswith("err_")
+    assert path.endswith(".csv")
+    df = pd.read_csv(path)
+    assert len(df) == 1
+    assert df["error_type"].iloc[0] == "ValueError"
+    assert df["claim_preview"].iloc[0] == "x"


### PR DESCRIPTION
[ ] All tests pass (pytest tests/core/test_embeddings.py -v)
[ ] Integration test passes with Ollama running (pytest tests/core/test_embeddings.py -m integration)
[ ] README and .env.example match the new env vars
[ ] OLLAMA_EMBEDDING_MODEL and OLLAMA_MODEL are documented as separate (embeddings vs LLM)
[ ] provider="ollama" works for experiments (e.g. advocate_mediator_climatecheck)
[ ] No regressions for existing Ollama embedding usage (backward compatible)