### PR TITLE
Spectrum experiment: advocate-mediator, evidence classification, comp…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.venv*
 env/
 venv/
 ENV/
@@ -183,3 +184,6 @@ concatenated_python_code.py
 
 # storage folder
 storage/
+
+# Drafts and narrative (LaTeX, visualizations) — not for version control
+drafts/

--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ The project follows a modular structure:
 - `factchecker/`: Main package directory
   - `core/`: Core functionality including LLM and embedding models
   - `experiments/`: Contains experiment scripts for different fact-checking approaches
+  - `services/`: Re-exports from `utils` for compatibility; analysis logic lives in `utils/`
   - `strategies/`: Core fact-checking strategy implementations
   - `utils/`: Utility functions and helper modules
-  - `tools/`: Utility scripts for tasks like downloading sources
+  - `tools/`: Utility scripts for tasks like downloading sources, analyzing results
 - `tests/`: Test suite following the same structure as the main package
 - `storage/`: Data storage for indices and other persistent data
 - `data/`: (gitignored) Directory for storing downloaded source documents
@@ -449,6 +450,17 @@ This will result in files being downloaded to:
 data/sources/ipcc/example_report.pdf
 data/sources/wmo/another.pdf
 ```
+
+#### 4. **Analyzing Spectrum results**
+
+To re-run metrics (classification report, log loss, top-k accuracy) on an existing Spectrum results CSV without calling the model:
+
+```bash
+python -m factchecker.tools.analyze_spectrum_results
+python -m factchecker.tools.analyze_spectrum_results --results path/to/spectrum_claims_results_*.csv
+```
+
+Business logic is in `factchecker.utils.spectrum_analysis` (same layer as `metrics`, `experiment_utils`); the tool is a thin CLI over it.
 
 ---
 

--- a/factchecker/experiments/advocate_mediator_climatefeedback_spectrum/__init__.py
+++ b/factchecker/experiments/advocate_mediator_climatefeedback_spectrum/__init__.py
@@ -1,0 +1,1 @@
+"""Spectrum experiment: weighted verdict distribution over Science Feedback (level 5) categories."""

--- a/factchecker/experiments/advocate_mediator_climatefeedback_spectrum/advocate_mediator_climatefeedback_spectrum.py
+++ b/factchecker/experiments/advocate_mediator_climatefeedback_spectrum/advocate_mediator_climatefeedback_spectrum.py
@@ -1,0 +1,1060 @@
+"""
+Spectrum experiment: advocate-mediator with weighted verdict distribution
+over the full Science Feedback claim review verdict scale.
+
+Each retrieved evidence chunk is first classified (supports / refutes / nei)
+by an EvidenceClassifierStep, then the advocate evaluates the claim using the
+classified evidence and the full SF label options.
+"""
+import json
+import logging
+import os
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import pandas as pd
+from llama_index.core import Settings
+from tqdm import tqdm
+
+from factchecker.experiments.advocate_mediator_climatefeedback.advocate_mediator_climatefeedback import (
+    setup_sources,
+)
+from factchecker.experiments.advocate_mediator_climatefeedback_spectrum.advocate_mediator_climatefeedback_spectrum_prompts import (
+    EVIDENCE_CLASSIFIER_REASONS,
+    SPECTRUM_ADVOCATE_SELECT_CHUNKS_INSTRUCTION,
+    SPECTRUM_ADVOCATE_VERDICT_FORMAT,
+    SPECTRUM_ADVOCATE_VERDICT_FORMAT_LABEL_AND_WEIGHTS,
+    SPECTRUM_ADVOCATE_VERDICT_FORMAT_WEIGHTS_ONLY,
+    SPECTRUM_CATEGORIES,
+    SPECTRUM_LABEL_OPTIONS,
+    SPECTRUM_MEDIATOR_USER_MESSAGE_SUFFIX,
+    SPECTRUM_MEDIATOR_VERDICT_FORMAT_INSTRUCTION,
+    spectrum_advocate_primer,
+    spectrum_evidence_classifier_system_prompt,
+    spectrum_evidence_classifier_user_prompt,
+    spectrum_mediator_primer,
+)
+from factchecker.experiments.advocate_mediator_climatefeedback_spectrum.weighted_parser import (
+    combine_advocate_weights_formula,
+    parse_advocate_response_label_only_with_chunk_selection,
+    parse_advocate_response_label_and_weights,
+    parse_advocate_response_weights_only,
+    parse_mediator_single_label,
+    parse_weighted_response,
+)
+from factchecker.steps.advocate import ADVOCATE_OUTPUT_MODES
+from factchecker.steps.evidence_classifier import EvidenceClassifierStep
+from factchecker.strategies.advocate_mediator import AdvocateMediatorStrategy
+from factchecker.utils.climatefeedback_utils import (
+    map_verdict,
+    sample_climatefeedback_claims,
+)
+
+from factchecker.prompts.advocate_prompts import chunk_stats_from_classified
+from factchecker.utils.experiment_utils import (
+    collect_evaluation_results,
+    configure_logging,
+    initialize_results_collectors,
+    save_evaluation_errors,
+    save_results,
+    show_evaluation_errors,
+    verify_environment,
+)
+from sklearn.metrics import accuracy_score
+
+from factchecker.utils.metrics import calculate_classification_metrics
+
+from factchecker.experiments.advocate_mediator_climatefeedback_spectrum.radar_chart import (
+    generate_radar_charts,
+)
+from factchecker.experiments.advocate_mediator_climatefeedback_spectrum.weighted_metrics import (
+    format_weighted_metrics,
+)
+
+logger = logging.getLogger(__name__)
+
+EXPERIMENT_PARAMS = {
+    "dataset_path": "datasets/Combined_Overview_Climate_Feedback_Claims.csv",
+    "total_samples": 10,
+    "correct_ratio": 0.3,
+    "chunk_size": 150,
+    "chunk_overlap": 20,
+    "main_source_directory": "data/sources",
+    "index_path": "data/indices/advocate_mediator_climatefeedback_spectrum",
+    "sources_csv": "factchecker/experiments/advocate_mediator_climatefeedback/advocate_mediator_climatefeedback_sources.csv",
+    "sources_output_folder": "data/sources",
+    "sources_skip_existing": True,
+    "sources_max_sources": 1,
+    "sources_url_column": "url",
+    "sources_output_filename_column": "output_filename",
+    "sources_output_subfolder_column": "output_subfolder",
+    "top_k": 8,
+    "advocate_output_mode": "label_only",  # or "label_and_weights", "weights_only"
+    "advocate_evidence_display": "full",  # or "relevant_only" — advocate sees only relevant_phrase per chunk (+ chunk_summary stats)
+    "mediator_evidence_relevant_only": False,  # when mediator sees evidence, pass only relevant_phrase (+ stats line)
+    "use_evidence_classifier": True,
+    "ablation_compare_chunk_labelling": False,  # run with and without chunk labelling and save comparison data
+    "compare_mediator_modes": False,  # report advocate_only vs formula vs LLM mediator (uses label_and_weights for formula)
+    "run_all_comparisons": True,  # one run: ablation + mediator evidence (no vs 3 chunks) + three-way (advocate/formula/LLM)
+    "comparison_runs": None,  # None = run all 6; or list of ints in [1,2,3,4,5,6] to run only those (e.g. [1,2,5,6] for relevant_only ablations only)
+    "parallel_claims": 0,  # 0 or 1 = sequential; >1 = max workers for parallel claim verification (e.g. 4 to max GPU)
+}
+
+
+def _advocate_primary_verdict(advocate_verdicts: List[List[str]]) -> List[str]:
+    """Per claim, return the consensus verdict across advocates (mode). Single advocate → that verdict."""
+    if not advocate_verdicts or not advocate_verdicts[0]:
+        return []
+    n_claims = len(advocate_verdicts[0])
+    out = []
+    for j in range(n_claims):
+        verdicts = [advocate_verdicts[i][j] for i in range(len(advocate_verdicts))]
+        mode, _ = Counter(verdicts).most_common(1)[0]
+        out.append(mode)
+    return out
+
+
+def _primary_verdict_from_final(final_verdict: str) -> str:
+    """Compute primary verdict (argmax of weights) from final_verdict; or return as-is if not JSON weights."""
+    if not final_verdict or not final_verdict.strip().startswith("{"):
+        return final_verdict
+    try:
+        weights = json.loads(final_verdict)
+        if isinstance(weights, dict) and weights:
+            primary = max(weights, key=lambda k: weights[k])
+            return primary
+    except (json.JSONDecodeError, TypeError):
+        pass
+    return final_verdict
+
+
+def setup_strategy(
+    params: Optional[Dict[str, Any]] = None,
+    downloaded_files: Optional[List[str]] = None,
+) -> AdvocateMediatorStrategy:
+    """Set up advocate-mediator strategy with spectrum (weighted) mediator."""
+    verify_environment()
+    p = {**EXPERIMENT_PARAMS, **(params or {})}
+    Settings.chunk_size = p["chunk_size"]
+    Settings.chunk_overlap = p["chunk_overlap"]
+    main_source_directory = p["main_source_directory"]
+    max_sources = p.get("sources_max_sources")
+
+    if downloaded_files:
+        indexer_options_list = [{"files": downloaded_files, "index_name": "ipcc"}]
+    elif max_sources is not None and max_sources <= 1:
+        indexer_options_list = [
+            {"source_directory": os.path.join(main_source_directory, "ipcc"), "index_name": "ipcc"}
+        ]
+    else:
+        indexer_options_list = [
+            {"source_directory": os.path.join(main_source_directory, "ipcc"), "index_name": "ipcc"},
+            {"source_directory": os.path.join(main_source_directory, "wmo"), "index_name": "wmo"},
+            {"source_directory": os.path.join(main_source_directory, "nipcc"), "index_name": "nipcc"},
+        ]
+
+    indexer_overrides = {
+        k: v
+        for k, v in p.items()
+        if k in ("chunk_size", "chunk_overlap", "embed_batch_size", "index_path", "embedding_type", "embedding_model", "show_progress")
+    }
+    if indexer_overrides:
+        base_index_path = indexer_overrides.pop("index_path", None)
+        for opts in indexer_options_list:
+            opts.update(indexer_overrides)
+            if base_index_path:
+                opts["index_path"] = os.path.join(base_index_path, opts["index_name"])
+
+    retriever_options_list = [{"top_k": p["top_k"]} for _ in indexer_options_list]
+
+    use_evidence_classifier = p.get("use_evidence_classifier", True)
+    evidence_classifier = None
+    if use_evidence_classifier:
+        evidence_classifier = EvidenceClassifierStep(
+            options={
+                "system_prompt": spectrum_evidence_classifier_system_prompt,
+                "user_prompt_fn": spectrum_evidence_classifier_user_prompt,
+                "include_reason": True,
+                "allowed_reasons": EVIDENCE_CLASSIFIER_REASONS,
+            }
+        )
+
+    mediator_mode = str(p.get("mediator_mode", "llm")).strip().lower()
+    advocate_output_mode = str(p.get("advocate_output_mode", "label_only")).strip().lower()
+    if advocate_output_mode not in ADVOCATE_OUTPUT_MODES:
+        advocate_output_mode = "label_only"
+    if mediator_mode == "llm_with_advocate_proof" and advocate_output_mode == "label_only":
+        # Advocate must pick chunks that support its verdict; mediator will see only those
+        verdict_format = SPECTRUM_ADVOCATE_VERDICT_FORMAT + " " + SPECTRUM_ADVOCATE_SELECT_CHUNKS_INSTRUCTION
+        verdict_parser = parse_advocate_response_label_only_with_chunk_selection
+    elif advocate_output_mode == "label_and_weights":
+        verdict_format = SPECTRUM_ADVOCATE_VERDICT_FORMAT_LABEL_AND_WEIGHTS
+        verdict_parser = parse_advocate_response_label_and_weights
+    elif advocate_output_mode == "weights_only":
+        verdict_format = SPECTRUM_ADVOCATE_VERDICT_FORMAT_WEIGHTS_ONLY
+        verdict_parser = parse_advocate_response_weights_only
+    else:
+        verdict_format = SPECTRUM_ADVOCATE_VERDICT_FORMAT
+        verdict_parser = None  # use default ((label)) parser
+    advocate_options = {
+        "system_prompt": spectrum_advocate_primer,
+        "label_options": SPECTRUM_LABEL_OPTIONS,
+        "evidence_classifier": evidence_classifier,
+        "verdict_format": verdict_format,
+        "verdict_parser": verdict_parser,
+        "advocate_output_mode": advocate_output_mode,
+        "advocate_evidence_display": str(p.get("advocate_evidence_display", "full")).strip().lower(),
+    }
+    if advocate_options["advocate_evidence_display"] not in ("full", "relevant_only"):
+        advocate_options["advocate_evidence_display"] = "full"
+    evidence_options = {}
+    mediator_options = {
+        "system_prompt": spectrum_mediator_primer,
+        "mediator_mode": mediator_mode,
+        "mediator_evidence_relevant_only": bool(p.get("mediator_evidence_relevant_only", False)),
+    }
+    if mediator_mode in ("llm", "llm_with_evidence", "llm_with_advocate_proof"):
+        mediator_options["verdict_parser"] = parse_mediator_single_label
+        mediator_options["verdict_format_instruction"] = SPECTRUM_MEDIATOR_VERDICT_FORMAT_INSTRUCTION
+        mediator_options["user_message_suffix"] = SPECTRUM_MEDIATOR_USER_MESSAGE_SUFFIX
+    else:
+        mediator_options["verdict_parser"] = parse_weighted_response
+    if mediator_mode == "formula":
+        mediator_options["formula_fn"] = combine_advocate_weights_formula
+    if mediator_mode == "llm_with_advocate_proof":
+        mediator_options["mediator_proof_max_chunks"] = int(p.get("mediator_proof_max_chunks", 3))
+
+    strategy = AdvocateMediatorStrategy(
+        indexer_options_list,
+        retriever_options_list,
+        advocate_options,
+        evidence_options,
+        mediator_options,
+    )
+    logger.info("Spectrum strategy initialized successfully")
+    return strategy
+
+
+def _evaluate_one_claim(
+    idx: Any,
+    row: pd.Series,
+    strategy: AdvocateMediatorStrategy,
+) -> Tuple[Any, pd.Series, bool, Union[tuple, Dict[str, Any]]]:
+    """Evaluate a single claim; return (idx, row, success, payload). Payload is 5-tuple on success, error dict on failure."""
+    claim_text = row["Claim"]
+    try:
+        result = strategy.evaluate_claim(claim_text)
+        return (idx, row, True, result)
+    except Exception as e:
+        logger.error("Error processing claim %s: %s", idx, e)
+        return (
+            idx,
+            row,
+            False,
+            {
+                "claim_index": idx,
+                "error_type": type(e).__name__,
+                "error_message": str(e),
+                "claim_preview": (claim_text[:80] + "...") if len(claim_text) > 80 else claim_text,
+            },
+        )
+
+
+def evaluate_spectrum_claims(
+    strategy: AdvocateMediatorStrategy,
+    sampled_claims: pd.DataFrame,
+    num_advocates: int,
+    parallel_claims: int = 0,
+):
+    """Evaluate claims with spectrum (weighted) mediator; collect primary verdict, weighted_verdicts, and evidence metadata.
+    If parallel_claims > 1, run claim verification in parallel with that many workers to utilize GPU."""
+    collectors = initialize_results_collectors(num_advocates)
+    collectors["weighted_verdicts"] = []
+    collectors["advocate_evidence_metadata"] = [[] for _ in range(num_advocates)]
+    collectors["chunk_stats"] = []  # per-claim stats: n_supports, n_refutes, n_nin, n_with/without relevant_phrase
+    errors: List[Dict[str, Any]] = []
+
+    items = list(sampled_claims.iterrows())
+    max_workers = max(1, int(parallel_claims)) if parallel_claims else 0
+    use_parallel = max_workers > 1
+
+    if use_parallel:
+        results_by_idx: Dict[Any, Tuple[Any, pd.Series, bool, Union[tuple, Dict[str, Any]]]] = {}
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {
+                executor.submit(_evaluate_one_claim, idx, row, strategy): idx
+                for idx, row in items
+            }
+            for future in tqdm(
+                as_completed(futures),
+                total=len(futures),
+                desc="Evaluating claims (parallel)",
+            ):
+                idx, row, success, payload = future.result()
+                results_by_idx[idx] = (idx, row, success, payload)
+        # Reorder to match original sampled_claims order
+        results = [results_by_idx[idx] for idx, _ in items]
+    else:
+        results = []
+        for idx, row in tqdm(items, total=len(items), desc="Evaluating claims"):
+            results.append(_evaluate_one_claim(idx, row, strategy))
+
+    for idx, row, success, payload in results:
+        claim_text = row["Claim"]
+        true_label = row["Climate Feedback"]
+        if not success:
+            errors.append(payload)
+            continue
+        (
+            final_verdict,
+            verdicts,
+            reasonings,
+            evidence_metadata_per_advocate,
+            advocate_weights_per_advocate,
+        ) = payload
+        primary_verdict = _primary_verdict_from_final(final_verdict)
+        collectors = collect_evaluation_results(
+            collectors,
+            (true_label, primary_verdict, verdicts, reasonings),
+            num_advocates=len(verdicts) if not collectors["advocate_evidences"] else None,
+            claim_index=idx,
+        )
+        if final_verdict and not final_verdict.strip().startswith("{"):
+            one_hot = {c: 1.0 if c == primary_verdict else 0.0 for c in SPECTRUM_CATEGORIES}
+            collectors["weighted_verdicts"].append(json.dumps(one_hot))
+        else:
+            collectors["weighted_verdicts"].append(final_verdict)
+        for i in range(num_advocates):
+            meta = (
+                evidence_metadata_per_advocate[i]
+                if evidence_metadata_per_advocate and i < len(evidence_metadata_per_advocate)
+                else None
+            )
+            collectors["advocate_evidence_metadata"][i].append(meta if meta else [])
+            w = (
+                advocate_weights_per_advocate[i]
+                if advocate_weights_per_advocate and i < len(advocate_weights_per_advocate)
+                else None
+            )
+            collectors["advocate_weighted_verdicts"][i].append(
+                json.dumps(w) if isinstance(w, dict) else w
+            )
+        # Per-claim chunk statistics (from first advocate when classifier is used)
+        meta0 = evidence_metadata_per_advocate[0] if evidence_metadata_per_advocate else []
+        collectors["chunk_stats"].append(chunk_stats_from_classified(meta0))
+
+    return collectors, errors
+
+
+def _spectrum_verdict_mapper_true(label: str) -> str:
+    """Map true label to Science Feedback claim verdict scale (level-7 granular)."""
+    return map_verdict(label, level=7)
+
+
+def _spectrum_verdict_mapper_predicted(label: str) -> str:
+    """Normalize predicted (primary) verdict for metrics: lowercase only; no category mapping so the full spectrum of model outputs is preserved for analysis."""
+    if not label:
+        return "unknown"
+    s = label.strip().lower().replace(" ", "_")
+    if s == "not_enough_info":
+        return "not_enough_information"
+    return s
+
+
+def _cluster_verdict_for_metrics(label: str, level: int) -> str:
+    """Map a single verdict (our format, e.g. mostly_accurate) to clustered label at given level (2 or 5) via map_verdict."""
+    if not label:
+        return "unknown"
+    # map_verdict expects space-separated keys
+    normalized_input = (label or "").strip().lower().replace("_", " ")
+    return map_verdict(normalized_input, level=level)
+
+
+def _formula_primary_from_collectors(collectors: Dict[str, Any]) -> Optional[List[str]]:
+    """
+    Compute formula mediator primary verdict per claim from advocate_weighted_verdicts.
+    Returns list of primary verdicts (one per claim) or None if weights are missing/invalid.
+    """
+    awv = collectors.get("advocate_weighted_verdicts")
+    if not awv or not awv[0]:
+        return None
+    n_claims = len(awv[0])
+    out = []
+    for j in range(n_claims):
+        weight_strs = [awv[i][j] if i < len(awv) else None for i in range(len(awv))]
+        weight_dicts = []
+        for s in weight_strs:
+            if not s or not (isinstance(s, str) and s.strip().startswith("{")):
+                continue
+            try:
+                d = json.loads(s)
+                if isinstance(d, dict) and d:
+                    weight_dicts.append(d)
+            except (json.JSONDecodeError, TypeError):
+                continue
+        if not weight_dicts:
+            out.append(None)
+            continue
+        primary, _ = combine_advocate_weights_formula(weight_dicts)
+        out.append(primary)
+    if all(p is None for p in out):
+        return None
+    return out
+
+
+def _build_spectrum_results_df(collectors: Dict[str, Any], sampled_claims: pd.DataFrame) -> pd.DataFrame:
+    """Build the full results DataFrame from collectors and sampled_claims (used in main and ablation)."""
+    claim_indices = collectors.get("claim_indices")
+    if claim_indices is not None and len(claim_indices) > 0:
+        claims_subset = sampled_claims.loc[claim_indices].reset_index(drop=True)
+    else:
+        claims_subset = sampled_claims
+
+    advocate_primary = _advocate_primary_verdict(collectors["advocate_verdicts"])
+    mediator_predicted = collectors["predicted_results"]
+    results_dict = {
+        "Claim": claims_subset["Claim"].values,
+        "True Label": collectors["true_labels"],
+        "Advocate Primary Verdict": advocate_primary,
+        "Mediator Predicted Verdict": mediator_predicted,
+        "Predicted Verdict": mediator_predicted,
+        "True Label (SF verdict)": [_spectrum_verdict_mapper_true(l) for l in collectors["true_labels"]],
+        "Weighted verdict": collectors["weighted_verdicts"],
+        "Mediator Reasoning": collectors["mediator_reasonings"],
+    }
+    chunk_stats_list = collectors.get("chunk_stats")
+    if chunk_stats_list and len(chunk_stats_list) == len(collectors["true_labels"]):
+        results_dict["Chunk stats"] = [
+            " | ".join(f"{k}={v}" for k, v in s.items()) if isinstance(s, dict) else str(s)
+            for s in chunk_stats_list
+        ]
+    meta_list = collectors.get("advocate_evidence_metadata")
+    for i in range(len(collectors["advocate_evidences"])):
+        if meta_list and i < len(meta_list):
+            evidence_seen = []
+            for meta in meta_list[i]:
+                parts = []
+                for m in meta:
+                    stance = m.get("stance", "")
+                    phrase = (m.get("relevant_phrase") or "").strip()
+                    reason = (m.get("reason") or "").strip()
+                    text = (m.get("text") or "").strip()
+                    block = f"[stance: {stance}]"
+                    if phrase:
+                        block += f' relevant_phrase: "{phrase}"'
+                    if reason:
+                        block += f" reason: {reason}"
+                    block += f"\n{text}"
+                    parts.append(block)
+                evidence_seen.append("\n---\n".join(parts) if parts else "")
+            results_dict[f"Advocate {i+1} Evidence"] = evidence_seen
+        else:
+            results_dict[f"Advocate {i+1} Evidence"] = collectors["advocate_evidences"][i]
+        results_dict[f"Advocate {i+1} Verdict"] = collectors["advocate_verdicts"][i]
+        results_dict[f"Advocate {i+1} Reasoning"] = collectors["advocate_reasonings"][i]
+        if meta_list and i < len(meta_list):
+            chunk_ids_col = []
+            relevant_phrases_col = []
+            reasons_col = []
+            for meta in meta_list[i]:
+                chunk_ids_col.append(",".join(str(m.get("chunk_id", "")) for m in meta))
+                relevant_phrases_col.append(" | ".join(str(m.get("relevant_phrase", "")) for m in meta))
+                reasons_col.append(" | ".join(str(m.get("reason", "")) for m in meta))
+            results_dict[f"Advocate {i+1} Chunk IDs"] = chunk_ids_col
+            results_dict[f"Advocate {i+1} Relevant phrases"] = relevant_phrases_col
+            results_dict[f"Advocate {i+1} Chunk reasons"] = reasons_col
+        awv = collectors.get("advocate_weighted_verdicts")
+        if awv and i < len(awv):
+            results_dict[f"Advocate {i+1} Weighted verdict"] = awv[i]
+
+    return pd.DataFrame(results_dict)
+
+
+def _run_all_comparisons(params, sampled_claims, downloaded_files, total_claims: int):
+    """
+    Run comparisons on the same claims. By default runs 1--6; use comparison_runs to run only a subset (e.g. [1,2,5,6]).
+    - Run 1: with chunk labelling, mediator no evidence (llm), advocate full chunks
+    - Run 2: with chunk labelling, mediator 3 advocate-selected chunks (full snippets)
+    - Run 3: without chunk labelling, mediator no evidence (llm)
+    - Run 4: with chunk labelling, label_and_weights, mediator llm (three-way)
+    - Run 5: like Run 1 but advocate_evidence_display=relevant_only
+    - Run 6: like Run 2 but mediator_evidence_relevant_only=True
+
+    Outputs only the comparison types whose required runs were executed (e.g. [1,2,5,6] -> mediator evidence, advocate display, mediator relevant_only).
+    """
+    parallel_claims = params.get("parallel_claims", 0) or 0
+    which = params.get("comparison_runs")
+    if which is None:
+        run_set = {1, 2, 3, 4, 5, 6}
+    else:
+        run_set = {int(x) for x in which if 1 <= int(x) <= 6}
+
+    c1 = c2 = c3 = c4 = c5 = c6 = None
+    n_adv = None
+
+    if 1 in run_set:
+        p1 = {**params, "use_evidence_classifier": True, "advocate_output_mode": "label_only", "mediator_mode": "llm"}
+        s1 = setup_strategy(params=p1, downloaded_files=downloaded_files)
+        n_adv = len(s1.advocate_steps)
+        c1, e1 = evaluate_spectrum_claims(s1, sampled_claims, n_adv, parallel_claims=parallel_claims)
+        show_evaluation_errors(e1, total_claims=total_claims)
+    if 2 in run_set:
+        p2 = {**params, "use_evidence_classifier": True, "advocate_output_mode": "label_only", "mediator_mode": "llm_with_advocate_proof", "mediator_proof_max_chunks": 3}
+        s2 = setup_strategy(params=p2, downloaded_files=downloaded_files)
+        if n_adv is None:
+            n_adv = len(s2.advocate_steps)
+        c2, e2 = evaluate_spectrum_claims(s2, sampled_claims, n_adv, parallel_claims=parallel_claims)
+        show_evaluation_errors(e2, total_claims=total_claims)
+    if 3 in run_set:
+        p3 = {**params, "use_evidence_classifier": False, "advocate_output_mode": "label_only", "mediator_mode": "llm"}
+        s3 = setup_strategy(params=p3, downloaded_files=downloaded_files)
+        if n_adv is None:
+            n_adv = len(s3.advocate_steps)
+        c3, e3 = evaluate_spectrum_claims(s3, sampled_claims, n_adv, parallel_claims=parallel_claims)
+        show_evaluation_errors(e3, total_claims=total_claims)
+    if 4 in run_set:
+        p4 = {**params, "use_evidence_classifier": True, "advocate_output_mode": "label_and_weights", "mediator_mode": "llm"}
+        s4 = setup_strategy(params=p4, downloaded_files=downloaded_files)
+        if n_adv is None:
+            n_adv = len(s4.advocate_steps)
+        c4, e4 = evaluate_spectrum_claims(s4, sampled_claims, n_adv, parallel_claims=parallel_claims)
+        show_evaluation_errors(e4, total_claims=total_claims)
+    if 5 in run_set:
+        p5 = {**params, "use_evidence_classifier": True, "advocate_output_mode": "label_only", "mediator_mode": "llm", "advocate_evidence_display": "relevant_only"}
+        s5 = setup_strategy(params=p5, downloaded_files=downloaded_files)
+        if n_adv is None:
+            n_adv = len(s5.advocate_steps)
+        c5, e5 = evaluate_spectrum_claims(s5, sampled_claims, n_adv, parallel_claims=parallel_claims)
+        show_evaluation_errors(e5, total_claims=total_claims)
+    if 6 in run_set:
+        p6 = {**params, "use_evidence_classifier": True, "advocate_output_mode": "label_only", "mediator_mode": "llm_with_advocate_proof", "mediator_proof_max_chunks": 3, "mediator_evidence_relevant_only": True}
+        s6 = setup_strategy(params=p6, downloaded_files=downloaded_files)
+        if n_adv is None:
+            n_adv = len(s6.advocate_steps)
+        c6, e6 = evaluate_spectrum_claims(s6, sampled_claims, n_adv, parallel_claims=parallel_claims)
+        show_evaluation_errors(e6, total_claims=total_claims)
+
+    collectors = [c1, c2, c3, c4, c5, c6]
+    sets_to_intersect = [set(c.get("claim_indices") or []) for c in collectors if c]
+    common = sorted(set.intersection(*sets_to_intersect)) if sets_to_intersect else []
+    if not common:
+        logger.warning("No claims succeeded in all executed runs; cannot compare.")
+        print("No claims succeeded in all executed runs; cannot compare.")
+        return
+
+    # True labels: use first available collector that has them (e.g. c1 or c4)
+    ref_collector = c1 or c2 or c4 or c5 or c3 or c6
+    def pos(c, ind): return c["claim_indices"].index(ind)
+    true_labels = [ref_collector["true_labels"][pos(ref_collector, i)] for i in common]
+    true_mapped = [_spectrum_verdict_mapper_true(l) for l in true_labels]
+
+    def _section(title: str) -> None:
+        print(f"\n{'='*60}\n{title}\n{'='*60}")
+
+    paths = []
+
+    # ----- 1) Ablation: with (Run 1) vs without (Run 3) chunk labelling -----
+    if c1 is not None and c3 is not None:
+        _section("1) Ablation: with vs without chunk labelling")
+        adv1 = _advocate_primary_verdict(c1["advocate_verdicts"])
+        med1 = [c1["predicted_results"][pos(c1, i)] for i in common]
+        adv3 = _advocate_primary_verdict(c3["advocate_verdicts"])
+        med3 = [c3["predicted_results"][pos(c3, i)] for i in common]
+        a1_m = [_spectrum_verdict_mapper_predicted(l) for l in adv1]
+        m1_m = [_spectrum_verdict_mapper_predicted(l) for l in med1]
+        a3_m = [_spectrum_verdict_mapper_predicted(l) for l in adv3]
+        m3_m = [_spectrum_verdict_mapper_predicted(l) for l in med3]
+        for level in (2, 5):
+            name = "L2 (correct/incorrect)" if level == 2 else "L5"
+            tc = [_cluster_verdict_for_metrics(l, level) for l in true_mapped]
+            print(f"\n--- {name} ---")
+            print("With labelling:   Advocate %.2f%%, Mediator %.2f%%" % (accuracy_score(tc, [_cluster_verdict_for_metrics(l, level) for l in a1_m]) * 100, accuracy_score(tc, [_cluster_verdict_for_metrics(l, level) for l in m1_m]) * 100))
+            print("Without labelling: Advocate %.2f%%, Mediator %.2f%%" % (accuracy_score(tc, [_cluster_verdict_for_metrics(l, level) for l in a3_m]) * 100, accuracy_score(tc, [_cluster_verdict_for_metrics(l, level) for l in m3_m]) * 100))
+        df_ablation = pd.DataFrame({
+            "Claim": [sampled_claims.loc[i, "Claim"] for i in common],
+            "True Label": true_labels,
+            "With_advocate": [adv1[pos(c1, i)] for i in common],
+            "With_mediator": [med1[pos(c1, i)] for i in common],
+            "Without_advocate": [adv3[pos(c3, i)] for i in common],
+            "Without_mediator": [med3[pos(c3, i)] for i in common],
+        })
+        path_ablation = save_results(df_ablation, base_path="experiments/results", prefix="spectrum_all_ablation")
+        paths.append(("Ablation", path_ablation))
+        print(f"\nAblation CSV: {path_ablation}")
+
+    # ----- 2) Mediator evidence: no evidence (Run 1) vs 3 chunks (Run 2) -----
+    if c1 is not None and c2 is not None:
+        _section("2) Mediator: no evidence vs 3 advocate-selected chunks")
+        med1 = [c1["predicted_results"][pos(c1, i)] for i in common]
+        med2 = [c2["predicted_results"][pos(c2, i)] for i in common]
+        m1_m = [_spectrum_verdict_mapper_predicted(l) for l in med1]
+        m2_m = [_spectrum_verdict_mapper_predicted(l) for l in med2]
+        for level in (2, 5):
+            name = "L2" if level == 2 else "L5"
+            tc = [_cluster_verdict_for_metrics(l, level) for l in true_mapped]
+            print(f"\n--- {name} --- No evidence: %.2f%% | 3 chunks: %.2f%%" % (accuracy_score(tc, [_cluster_verdict_for_metrics(l, level) for l in m1_m]) * 100, accuracy_score(tc, [_cluster_verdict_for_metrics(l, level) for l in m2_m]) * 100))
+        df_med_ev = pd.DataFrame({
+            "Claim": [sampled_claims.loc[i, "Claim"] for i in common],
+            "True Label": true_labels,
+            "Mediator_no_evidence": med1,
+            "Mediator_3_chunks": med2,
+        })
+        path_med_ev = save_results(df_med_ev, base_path="experiments/results", prefix="spectrum_all_mediator_evidence")
+        paths.append(("Mediator evidence", path_med_ev))
+        print(f"\nMediator evidence CSV: {path_med_ev}")
+
+    # ----- 3) Three-way: advocate_only, formula, LLM (from Run 4) -----
+    if c4 is not None:
+        _section("3) Three-way: Advocate-only vs Formula vs LLM mediator")
+        adv4 = _advocate_primary_verdict(c4["advocate_verdicts"])
+        med4 = [c4["predicted_results"][pos(c4, i)] for i in common]
+        formula_primary = _formula_primary_from_collectors(c4)
+        if formula_primary is not None:
+            formula_list = [formula_primary[pos(c4, i)] for i in common]
+            a4_m = [_spectrum_verdict_mapper_predicted(l) for l in adv4]
+            f_m = [_spectrum_verdict_mapper_predicted(l) for l in formula_list]
+            m4_m = [_spectrum_verdict_mapper_predicted(l) for l in med4]
+            for level in (2, 5):
+                name = "L2" if level == 2 else "L5"
+                tc = [_cluster_verdict_for_metrics(l, level) for l in true_mapped]
+                print(f"\n--- {name} --- Advocate-only: %.2f%% | Formula: %.2f%% | LLM: %.2f%%" % (
+                    accuracy_score(tc, [_cluster_verdict_for_metrics(l, level) for l in a4_m]) * 100,
+                    accuracy_score(tc, [_cluster_verdict_for_metrics(l, level) for l in f_m]) * 100,
+                    accuracy_score(tc, [_cluster_verdict_for_metrics(l, level) for l in m4_m]) * 100,
+                ))
+            df_three = pd.DataFrame({
+                "Claim": [sampled_claims.loc[i, "Claim"] for i in common],
+                "True Label": true_labels,
+                "Advocate_only": [adv4[pos(c4, i)] for i in common],
+                "Formula": formula_list,
+                "LLM_mediator": med4,
+            })
+            path_three = save_results(df_three, base_path="experiments/results", prefix="spectrum_all_threeway")
+            paths.append(("Three-way", path_three))
+            print(f"\nThree-way CSV: {path_three}")
+        else:
+            print("(Formula not available: no advocate weights in Run 4.)")
+
+    # ----- 4) Advocate evidence: full chunks vs relevant_only (Run 1 vs Run 5) -----
+    if c1 is not None and c5 is not None:
+        _section("4) Advocate: full chunks vs relevant parts only (+ chunk stats)")
+        adv1 = _advocate_primary_verdict(c1["advocate_verdicts"])
+        med1 = [c1["predicted_results"][pos(c1, i)] for i in common]
+        adv5 = _advocate_primary_verdict(c5["advocate_verdicts"])
+        med5 = [c5["predicted_results"][pos(c5, i)] for i in common]
+        a1_m = [_spectrum_verdict_mapper_predicted(l) for l in adv1]
+        m1_m = [_spectrum_verdict_mapper_predicted(l) for l in med1]
+        a5_m = [_spectrum_verdict_mapper_predicted(l) for l in adv5]
+        m5_m = [_spectrum_verdict_mapper_predicted(l) for l in med5]
+        for level in (2, 5):
+            name = "L2" if level == 2 else "L5"
+            tc = [_cluster_verdict_for_metrics(l, level) for l in true_mapped]
+            print(f"\n--- {name} --- Full: Advocate %.2f%% / Mediator %.2f%% | Relevant-only: Advocate %.2f%% / Mediator %.2f%%" % (
+                accuracy_score(tc, [_cluster_verdict_for_metrics(l, level) for l in a1_m]) * 100,
+                accuracy_score(tc, [_cluster_verdict_for_metrics(l, level) for l in m1_m]) * 100,
+                accuracy_score(tc, [_cluster_verdict_for_metrics(l, level) for l in a5_m]) * 100,
+                accuracy_score(tc, [_cluster_verdict_for_metrics(l, level) for l in m5_m]) * 100,
+            ))
+        df_adv_ev = pd.DataFrame({
+            "Claim": [sampled_claims.loc[i, "Claim"] for i in common],
+            "True Label": true_labels,
+            "Full_advocate": [adv1[pos(c1, i)] for i in common],
+            "Full_mediator": [med1[pos(c1, i)] for i in common],
+            "Relevant_only_advocate": [adv5[pos(c5, i)] for i in common],
+            "Relevant_only_mediator": [med5[pos(c5, i)] for i in common],
+        })
+        path_adv_ev = save_results(df_adv_ev, base_path="experiments/results", prefix="spectrum_all_advocate_evidence_display")
+        paths.append(("Advocate display", path_adv_ev))
+        print(f"\nAdvocate evidence display CSV: {path_adv_ev}")
+
+    # ----- 5) Mediator evidence: full snippets vs relevant_only (Run 2 vs Run 6) -----
+    if c2 is not None and c6 is not None:
+        _section("5) Mediator: full snippets vs relevant parts only (+ stats)")
+        med2 = [c2["predicted_results"][pos(c2, i)] for i in common]
+        med6 = [c6["predicted_results"][pos(c6, i)] for i in common]
+        m2_m = [_spectrum_verdict_mapper_predicted(l) for l in med2]
+        m6_m = [_spectrum_verdict_mapper_predicted(l) for l in med6]
+        for level in (2, 5):
+            name = "L2" if level == 2 else "L5"
+            tc = [_cluster_verdict_for_metrics(l, level) for l in true_mapped]
+            print(f"\n--- {name} --- Full snippets: %.2f%% | Relevant-only: %.2f%%" % (
+                accuracy_score(tc, [_cluster_verdict_for_metrics(l, level) for l in m2_m]) * 100,
+                accuracy_score(tc, [_cluster_verdict_for_metrics(l, level) for l in m6_m]) * 100,
+            ))
+        df_med_rel = pd.DataFrame({
+            "Claim": [sampled_claims.loc[i, "Claim"] for i in common],
+            "True Label": true_labels,
+            "Mediator_full_snippets": med2,
+            "Mediator_relevant_only": med6,
+        })
+        path_med_rel = save_results(df_med_rel, base_path="experiments/results", prefix="spectrum_all_mediator_relevant_only")
+        paths.append(("Mediator relevant-only", path_med_rel))
+        print(f"\nMediator relevant-only CSV: {path_med_rel}")
+
+    summary = f"Comparisons: {len(common)} claims. " + " | ".join(f"{n}: {p}" for n, p in paths)
+    logger.info(summary)
+    print(f"\n{summary}")
+
+
+def _run_ablation_chunk_labelling(params, sampled_claims, downloaded_files, total_claims: int):
+    """Run experiment twice (with and without evidence classifier) on same claims; compare normalized metrics and save comparison CSV."""
+    num_advocates = 1  # setup_strategy will set this
+    # Run 1: with chunk labelling
+    params_with = {**params, "use_evidence_classifier": True}
+    strategy_with = setup_strategy(params=params_with, downloaded_files=downloaded_files)
+    num_advocates = len(strategy_with.advocate_steps)
+    parallel_claims = params.get("parallel_claims", 0) or 0
+    collectors1, errors1 = evaluate_spectrum_claims(
+        strategy_with, sampled_claims, num_advocates, parallel_claims=parallel_claims
+    )
+    show_evaluation_errors(errors1, total_claims=total_claims)
+    # Run 2: without chunk labelling
+    params_without = {**params, "use_evidence_classifier": False}
+    strategy_without = setup_strategy(params=params_without, downloaded_files=downloaded_files)
+    collectors2, errors2 = evaluate_spectrum_claims(
+        strategy_without, sampled_claims, num_advocates, parallel_claims=parallel_claims
+    )
+    show_evaluation_errors(errors2, total_claims=total_claims)
+
+    common_indices = sorted(
+        set(collectors1.get("claim_indices") or []) & set(collectors2.get("claim_indices") or [])
+    )
+    if not common_indices:
+        logger.warning("Ablation: no claims succeeded in both runs; cannot compare.")
+        print("Ablation: no claims succeeded in both runs; cannot compare.")
+        return
+
+    # Align by claim index
+    pos1_list = [collectors1["claim_indices"].index(idx) for idx in common_indices]
+    pos2_list = [collectors2["claim_indices"].index(idx) for idx in common_indices]
+    true_aligned = [collectors1["true_labels"][p] for p in pos1_list]
+    advocate_primary_1 = _advocate_primary_verdict(collectors1["advocate_verdicts"])
+    advocate_primary_2 = _advocate_primary_verdict(collectors2["advocate_verdicts"])
+    with_advocate = [advocate_primary_1[p] for p in pos1_list]
+    with_mediator = [collectors1["predicted_results"][p] for p in pos1_list]
+    without_advocate = [advocate_primary_2[p] for p in pos2_list]
+    without_mediator = [collectors2["predicted_results"][p] for p in pos2_list]
+
+    true_mapped = [_spectrum_verdict_mapper_true(l) for l in true_aligned]
+    with_adv_mapped = [_spectrum_verdict_mapper_predicted(l) for l in with_advocate]
+    with_med_mapped = [_spectrum_verdict_mapper_predicted(l) for l in with_mediator]
+    without_adv_mapped = [_spectrum_verdict_mapper_predicted(l) for l in without_advocate]
+    without_med_mapped = [_spectrum_verdict_mapper_predicted(l) for l in without_mediator]
+
+    # Normalized (level 2 and 5) metrics for comparison
+    comparison_lines = [
+        f"Ablation: compared {len(common_indices)} claims (successful in both runs).",
+        "",
+    ]
+    for level in (2, 5):
+        level_name = "correct/incorrect (L2)" if level == 2 else "level-5 (L5)"
+        true_clustered = [_cluster_verdict_for_metrics(l, level) for l in true_mapped]
+        with_adv_cluster = [_cluster_verdict_for_metrics(l, level) for l in with_adv_mapped]
+        with_med_cluster = [_cluster_verdict_for_metrics(l, level) for l in with_med_mapped]
+        without_adv_cluster = [_cluster_verdict_for_metrics(l, level) for l in without_adv_mapped]
+        without_med_cluster = [_cluster_verdict_for_metrics(l, level) for l in without_med_mapped]
+        acc_with_adv = accuracy_score(true_clustered, with_adv_cluster)
+        acc_with_med = accuracy_score(true_clustered, with_med_cluster)
+        acc_without_adv = accuracy_score(true_clustered, without_adv_cluster)
+        acc_without_med = accuracy_score(true_clustered, without_med_cluster)
+        comparison_lines.append(f"--- Normalized {level_name} ---")
+        comparison_lines.append("With chunk labelling: Advocate accuracy=%.2f%%, Mediator accuracy=%.2f%%" % (acc_with_adv * 100, acc_with_med * 100))
+        comparison_lines.append("Without chunk labelling: Advocate accuracy=%.2f%%, Mediator accuracy=%.2f%%" % (acc_without_adv * 100, acc_without_med * 100))
+        comparison_lines.append("")
+    comparison_str = "\n".join(comparison_lines)
+    logger.info(comparison_str)
+    print(comparison_str)
+
+    # Full analysis and metrics for both runs (aligned on common_indices)
+    weighted_with = [collectors1["weighted_verdicts"][p] for p in pos1_list]
+    weighted_without = [collectors2["weighted_verdicts"][p] for p in pos2_list]
+
+    def _print_section(title: str) -> None:
+        print(f"\n{'='*60}\n{title}\n{'='*60}")
+
+    # --- With chunk labelling ---
+    _print_section("With chunk labelling — full metrics")
+    print("\n--- Advocate primary vs true (14-way) ---")
+    print(calculate_classification_metrics(true_mapped, with_adv_mapped, verdict_mapper=None))
+    print("\n--- Mediator predicted vs true (14-way) ---")
+    print(calculate_classification_metrics(true_mapped, with_med_mapped, verdict_mapper=None))
+    for level in (2, 5):
+        level_name = "correct/incorrect (L2)" if level == 2 else "level-5 (L5)"
+        true_c = [_cluster_verdict_for_metrics(l, level) for l in true_mapped]
+        with_adv_c = [_cluster_verdict_for_metrics(l, level) for l in with_adv_mapped]
+        with_med_c = [_cluster_verdict_for_metrics(l, level) for l in with_med_mapped]
+        print(f"\n--- Advocate vs true (normalized {level_name}) ---")
+        print(calculate_classification_metrics(true_c, with_adv_c, verdict_mapper=None))
+        print(f"\n--- Mediator vs true (normalized {level_name}) ---")
+        print(calculate_classification_metrics(true_c, with_med_c, verdict_mapper=None))
+    print(format_weighted_metrics(true_mapped, weighted_with))
+
+    # --- Without chunk labelling ---
+    _print_section("Without chunk labelling — full metrics")
+    print("\n--- Advocate primary vs true (14-way) ---")
+    print(calculate_classification_metrics(true_mapped, without_adv_mapped, verdict_mapper=None))
+    print("\n--- Mediator predicted vs true (14-way) ---")
+    print(calculate_classification_metrics(true_mapped, without_med_mapped, verdict_mapper=None))
+    for level in (2, 5):
+        level_name = "correct/incorrect (L2)" if level == 2 else "level-5 (L5)"
+        true_c = [_cluster_verdict_for_metrics(l, level) for l in true_mapped]
+        without_adv_c = [_cluster_verdict_for_metrics(l, level) for l in without_adv_mapped]
+        without_med_c = [_cluster_verdict_for_metrics(l, level) for l in without_med_mapped]
+        print(f"\n--- Advocate vs true (normalized {level_name}) ---")
+        print(calculate_classification_metrics(true_c, without_adv_c, verdict_mapper=None))
+        print(f"\n--- Mediator vs true (normalized {level_name}) ---")
+        print(calculate_classification_metrics(true_c, without_med_c, verdict_mapper=None))
+    print(format_weighted_metrics(true_mapped, weighted_without))
+
+    # Build comparison CSV
+    claims_subset = sampled_claims.loc[common_indices].reset_index(drop=True)
+    comparison_df = pd.DataFrame({
+        "claim_index": common_indices,
+        "Claim": claims_subset["Claim"].values,
+        "True Label": true_aligned,
+        "With labelling Advocate Primary": with_advocate,
+        "With labelling Mediator Primary": with_mediator,
+        "Without labelling Advocate Primary": without_advocate,
+        "Without labelling Mediator Primary": without_mediator,
+        "True (mapped)": true_mapped,
+        "With Advocate (mapped)": with_adv_mapped,
+        "With Mediator (mapped)": with_med_mapped,
+        "Without Advocate (mapped)": without_adv_mapped,
+        "Without Mediator (mapped)": without_med_mapped,
+    })
+    comparison_path = save_results(
+        comparison_df,
+        base_path="experiments/results",
+        prefix="spectrum_ablation_chunk_labelling",
+    )
+    logger.info("Ablation comparison CSV saved to: %s", comparison_path)
+    print(f"\nComparison saved to: {comparison_path}")
+
+    # Save full results for each run so we can compare all columns (evidence, reasoning, etc.)
+    df_with = _build_spectrum_results_df(collectors1, sampled_claims)
+    df_without = _build_spectrum_results_df(collectors2, sampled_claims)
+    path_with = save_results(
+        df_with,
+        base_path="experiments/results",
+        prefix="spectrum_ablation_with_labelling",
+    )
+    path_without = save_results(
+        df_without,
+        base_path="experiments/results",
+        prefix="spectrum_ablation_without_labelling",
+    )
+    logger.info("Ablation full results: with labelling=%s, without labelling=%s", path_with, path_without)
+    print(f"Full results: with labelling={path_with}, without labelling={path_without}")
+
+    # Radar charts for both runs (subset aligned to common_indices)
+    radar_dir = "experiments/results/spectrum_radar"
+    radar_with = generate_radar_charts(
+        weighted_with,
+        output_dir=f"{radar_dir}/ablation_with_labelling",
+        per_claim=False,
+        summary=True,
+    )
+    radar_without = generate_radar_charts(
+        weighted_without,
+        output_dir=f"{radar_dir}/ablation_without_labelling",
+        per_claim=False,
+        summary=True,
+    )
+    if radar_with or radar_without:
+        logger.info("Ablation radar charts: with=%s, without=%s", radar_with, radar_without)
+        print(f"Ablation radar: with_labelling={radar_with}, without_labelling={radar_without}")
+
+    n1 = len(collectors1.get("true_labels") or [])
+    n2 = len(collectors2.get("true_labels") or [])
+    summary = (
+        f"Ablation summary: with labelling {n1}/{total_claims} claims ok ({len(errors1)} errors); "
+        f"without labelling {n2}/{total_claims} claims ok ({len(errors2)} errors); "
+        f"compared on {len(common_indices)} claims."
+    )
+    logger.info(summary)
+    print(f"\n{summary}")
+
+
+def main(experiment_options: Optional[Dict[str, Any]] = None):
+    """Run the Spectrum (weighted verdicts) advocate-mediator Climate Feedback experiment."""
+    configure_logging()
+    params = {**EXPERIMENT_PARAMS, **(experiment_options or {})}
+    verify_environment()
+    downloaded_files = setup_sources(params=params)
+    Settings.chunk_size = params.get("chunk_size", 150)
+    Settings.chunk_overlap = params.get("chunk_overlap", 20)
+
+    logger.info("Loading and sampling claims...")
+    sampled_claims = sample_climatefeedback_claims(
+        csv_path=params["dataset_path"],
+        total_samples=params["total_samples"],
+        correct_ratio=params["correct_ratio"],
+    )
+    total_claims = len(sampled_claims)
+
+    # All comparisons in one go: ablation + mediator evidence + three-way
+    if params.get("run_all_comparisons"):
+        _run_all_comparisons(params, sampled_claims, downloaded_files, total_claims)
+        return
+
+    # Ablation: run with and without chunk labelling on same claims, then compare
+    if params.get("ablation_compare_chunk_labelling"):
+        _run_ablation_chunk_labelling(params, sampled_claims, downloaded_files, total_claims)
+        return
+
+    # Three-way mediator comparison: advocate_only vs formula vs LLM (needs advocate weights)
+    if params.get("compare_mediator_modes"):
+        params = {**params, "advocate_output_mode": "label_and_weights"}
+
+    strategy = setup_strategy(params=params, downloaded_files=downloaded_files)
+    num_advocates = len(strategy.advocate_steps)
+    parallel_claims = params.get("parallel_claims", 0) or 0
+    collectors, errors = evaluate_spectrum_claims(
+        strategy, sampled_claims, num_advocates, parallel_claims=parallel_claims
+    )
+    show_evaluation_errors(errors, total_claims=total_claims)
+
+    total_claims = len(sampled_claims)
+    n_ok = len(collectors["true_labels"])
+    n_err = len(errors)
+    errors_file = None
+    if errors:
+        errors_file = save_evaluation_errors(
+            errors, base_path="experiments/results", prefix="spectrum_evaluation_errors"
+        )
+        if errors_file:
+            logger.info("Evaluation errors saved to: %s", errors_file)
+
+    if n_ok == 0:
+        logger.warning("No claims were successfully evaluated; skipping results and metrics.")
+        print(f"Run summary: 0/{total_claims} claims evaluated successfully. {n_err} errors.")
+        return
+
+    results_df = _build_spectrum_results_df(collectors, sampled_claims)
+    advocate_primary = _advocate_primary_verdict(collectors["advocate_verdicts"])
+    mediator_predicted = collectors["predicted_results"]
+    results_file = save_results(results_df, base_path="experiments/results", prefix="spectrum_claims_results")
+    logger.info("Results saved to: %s", results_file)
+
+    # Radar chart(s) for weighted verdict distribution
+    radar_paths = generate_radar_charts(
+        collectors["weighted_verdicts"],
+        output_dir="experiments/results/spectrum_radar",
+        per_claim=True,
+        summary=True,
+    )
+    if radar_paths:
+        logger.info("Radar charts saved: %s", radar_paths)
+
+    # Metrics on Science Feedback claim verdict scale (granular, level-7)
+    true_mapped = [_spectrum_verdict_mapper_true(l) for l in collectors["true_labels"]]
+    advocate_primary_mapped = [_spectrum_verdict_mapper_predicted(p) for p in advocate_primary]
+    mediator_pred_mapped = [_spectrum_verdict_mapper_predicted(p) for p in mediator_predicted]
+
+    # Three-way mediator comparison: advocate_only vs formula vs LLM (when compare_mediator_modes and we have weights)
+    if params.get("compare_mediator_modes"):
+        formula_primary = _formula_primary_from_collectors(collectors)
+        if formula_primary is not None:
+            formula_mapped = [_spectrum_verdict_mapper_predicted(p) for p in formula_primary]
+            print("\n" + "=" * 60)
+            print("Mediator comparison: Advocate-only vs Formula vs LLM mediator")
+            print("=" * 60)
+            for name, pred_mapped in [
+                ("Advocate-only (normalized)", advocate_primary_mapped),
+                ("Formula (avg weights + argmax)", formula_mapped),
+                ("LLM mediator", mediator_pred_mapped),
+            ]:
+                print(f"\n--- {name} vs true (14-way) ---")
+                print(calculate_classification_metrics(true_mapped, pred_mapped, verdict_mapper=None))
+            for level in (2, 5):
+                level_name = "correct/incorrect (L2)" if level == 2 else "level-5 (L5)"
+                true_c = [_cluster_verdict_for_metrics(l, level) for l in true_mapped]
+                print(f"\n--- Normalized {level_name} ---")
+                for name, pred_mapped in [
+                    ("Advocate-only", advocate_primary_mapped),
+                    ("Formula", formula_mapped),
+                    ("LLM mediator", mediator_pred_mapped),
+                ]:
+                    pred_c = [_cluster_verdict_for_metrics(l, level) for l in pred_mapped]
+                    acc = accuracy_score(true_c, pred_c)
+                    print(f"  {name}: accuracy = {acc:.2%}")
+            # Save mediator comparison CSV
+            comparison_df = pd.DataFrame({
+                "Claim": results_df["Claim"].values,
+                "True Label": collectors["true_labels"],
+                "Advocate-only Primary": advocate_primary,
+                "Formula Primary": formula_primary,
+                "LLM Mediator Primary": mediator_predicted,
+            })
+            comparison_path = save_results(
+                comparison_df,
+                base_path="experiments/results",
+                prefix="spectrum_mediator_comparison",
+            )
+            logger.info("Mediator comparison CSV saved to: %s", comparison_path)
+            print(f"\nMediator comparison saved to: {comparison_path}")
+        else:
+            print("\nMediator comparison skipped: no advocate weights (need advocate_output_mode=label_and_weights).")
+
+    metrics_advocate = calculate_classification_metrics(
+        true_mapped,
+        advocate_primary_mapped,
+        verdict_mapper=None,
+    )
+    logger.info("\n--- Advocate primary verdict (consensus) vs true ---")
+    logger.info("Classification Metrics (Science Feedback claim verdict scale):")
+    print("\n--- Advocate primary verdict (consensus) vs true ---")
+    print(metrics_advocate)
+
+    metrics_mediator = calculate_classification_metrics(
+        true_mapped,
+        mediator_pred_mapped,
+        verdict_mapper=None,
+    )
+    logger.info("\n--- Mediator predicted verdict vs true ---")
+    logger.info("Classification Metrics (Science Feedback claim verdict scale):")
+    print("\n--- Mediator predicted verdict vs true ---")
+    print(metrics_mediator)
+
+    # Normalized (clustered) metrics: level 2 (correct/incorrect) and level 5
+    for level in (2, 5):
+        true_clustered = [_cluster_verdict_for_metrics(l, level) for l in true_mapped]
+        advocate_clustered = [_cluster_verdict_for_metrics(l, level) for l in advocate_primary_mapped]
+        mediator_clustered = [_cluster_verdict_for_metrics(l, level) for l in mediator_pred_mapped]
+        level_name = "correct/incorrect" if level == 2 else "level-5 categories"
+        metrics_advocate_cluster = calculate_classification_metrics(
+            true_clustered,
+            advocate_clustered,
+            verdict_mapper=None,
+        )
+        metrics_mediator_cluster = calculate_classification_metrics(
+            true_clustered,
+            mediator_clustered,
+            verdict_mapper=None,
+        )
+        logger.info("\n--- Advocate primary vs true (normalized, level=%s: %s) ---", level, level_name)
+        print("\n--- Advocate primary vs true (normalized, level=%s: %s) ---" % (level, level_name))
+        print(metrics_advocate_cluster)
+        logger.info("\n--- Mediator predicted vs true (normalized, level=%s: %s) ---", level, level_name)
+        print("\n--- Mediator predicted vs true (normalized, level=%s: %s) ---" % (level, level_name))
+        print(metrics_mediator_cluster)
+
+    # Weighted distribution metrics (log loss, top-2, top-3 accuracy)
+    weighted_metrics_str = format_weighted_metrics(
+        true_mapped,
+        collectors["weighted_verdicts"],
+    )
+    logger.info(weighted_metrics_str)
+    print(weighted_metrics_str)
+
+    summary = f"Run summary: {n_ok}/{total_claims} claims evaluated successfully."
+    if n_err:
+        summary += f" {n_err} errors."
+        if errors_file:
+            summary += f" Details: {errors_file}"
+    print(f"\n{summary}")
+
+
+if __name__ == "__main__":
+    main()

--- a/factchecker/experiments/advocate_mediator_climatefeedback_spectrum/advocate_mediator_climatefeedback_spectrum_prompts.py
+++ b/factchecker/experiments/advocate_mediator_climatefeedback_spectrum/advocate_mediator_climatefeedback_spectrum_prompts.py
@@ -1,0 +1,356 @@
+"""
+Prompts and category definitions for the Spectrum experiment, thoroughly aligned
+with Science Feedback's claim review methodology.
+
+Reference: https://science.feedback.org/process/#Claim-review
+
+Key distinction Science Feedback makes:
+- **Statements of fact** are rated on the accurate/inaccurate axis
+  (does the statement match available data/observations?).
+- **Explanations, hypotheses, and theories** are rated on the correct/incorrect axis
+  (has the explanation been well-tested and confirmed by observations?).
+
+Credibility tiers:
+  Very High  — accurate, correct
+  High       — mostly_accurate, mostly_correct
+  Neutral    — correct_but, partially_correct, lacks_context, imprecise
+  Low        — unsupported, misleading
+  Very Low   — inaccurate, incorrect
+  Issues     — flawed_reasoning
+  Abstain    — not_enough_information
+"""
+
+import json
+from textwrap import dedent
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Verdict categories (full granular scale, snake_case)
+# ---------------------------------------------------------------------------
+SPECTRUM_CATEGORIES = [
+    "accurate",
+    "correct",
+    "mostly_accurate",
+    "mostly_correct",
+    "correct_but",
+    "partially_correct",
+    "lacks_context",
+    "imprecise",
+    "unsupported",
+    "misleading",
+    "inaccurate",
+    "incorrect",
+    "flawed_reasoning",
+    "not_enough_information",
+]
+
+# ---------------------------------------------------------------------------
+# Label options dict — maps each verdict to its Science Feedback description.
+# Passed as label_options to the advocate so the LLM understands every choice.
+# ---------------------------------------------------------------------------
+SPECTRUM_LABEL_OPTIONS: dict[str, str] = {
+    "accurate": (
+        "Statement of fact that is consistent with available data/observations "
+        "and does not omit relevant context."
+    ),
+    "correct": (
+        "Explanation, hypothesis, or theory that has been well-tested in "
+        "scientific studies and generates predictions confirmed by observations."
+    ),
+    "mostly_accurate": (
+        "Statement of fact that is largely consistent with data but needs "
+        "some clarification or additional information to be fully accurate."
+    ),
+    "mostly_correct": (
+        "Explanation that is well-tested but whose formulation slightly "
+        "overstates scientific confidence or distorts predictions."
+    ),
+    "correct_but": (
+        "Explanation that is correct in substance but contains a caveat — "
+        "e.g. it is true under specific conditions not mentioned in the claim."
+    ),
+    "partially_correct": (
+        "Claim that significantly overstates scientific confidence in a theory, "
+        "or is only correct in a narrow sense."
+    ),
+    "lacks_context": (
+        "Claim that omits important observations or explanations that would "
+        "change the reader's takeaway."
+    ),
+    "imprecise": (
+        "Claim that uses ill-defined terms or lacks specifics so that one "
+        "cannot unambiguously know what is meant."
+    ),
+    "unsupported": (
+        "Claim made without adequate reference, or the available evidence "
+        "does not support the statement."
+    ),
+    "misleading": (
+        "Claim that contains an element of truth but leaves the reader "
+        "with a false understanding of reality (e.g. by omitting context)."
+    ),
+    "inaccurate": (
+        "Statement of fact in direct contradiction with available "
+        "data/observations."
+    ),
+    "incorrect": (
+        "Explanation or theory whose predictions have been invalidated "
+        "by observations."
+    ),
+    "flawed_reasoning": (
+        "The conclusion does not follow from the premises; logical error "
+        "in the argument."
+    ),
+    "not_enough_information": (
+        "The provided evidence is insufficient to assess the claim."
+    ),
+}
+
+# ---------------------------------------------------------------------------
+# Evidence classifier — optional experiment-level prompts for
+# EvidenceClassifierStep (supports / refutes / not_enough_information per chunk).
+# Winning strategy: persona + direct order in user message; optional reason sub-category.
+# ---------------------------------------------------------------------------
+EVIDENCE_CLASSIFIER_REASONS = (
+    "same_number",
+    "higher_number",
+    "smaller_number",
+    "contradiction",
+    "partial_or_qualification",
+    "different_scope_or_timeframe",
+)
+
+spectrum_evidence_classifier_system_prompt = dedent("""\
+You are an expert evidence classifier for climate and environmental claims, with knowledge of
+climate change, climate science, environmental science, physics, and energy science.
+
+Your task is to classify each evidence piece as supports, refutes, or not_enough_information
+with respect to the claim. Do NOT evaluate whether the claim is true — only whether the
+evidence relates to it.
+
+For each evidence piece assign exactly one stance:
+- "supports"                — the evidence supports or is consistent with the claim
+- "refutes"                 — the evidence contradicts or is inconsistent with the claim
+- "not_enough_information"  — the evidence is irrelevant or too vague to support or refute the claim
+
+You may use not_enough_information whenever the evidence does not clearly support or refute the claim.
+
+Rules:
+1. Judge each evidence piece independently. Base your classification only on the text provided.
+2. For climate/science claims, consider whether the evidence addresses the same quantities,
+   mechanisms, or time frames as the claim; if it does not, use not_enough_information.
+3. When stance is supports or refutes, also provide a reason (see allowed values in the user message).
+4. Respond with ONLY a valid JSON array (no commentary before or after).
+""")
+
+
+def spectrum_evidence_classifier_user_prompt(
+    claim: str,
+    evidence_texts: list[str],
+    include_relevant_phrase: bool = False,
+    chunk_ids: Optional[list[str]] = None,
+    include_reason: bool = True,
+) -> str:
+    """Build the evidence-classifier user prompt for Spectrum: direct order + payload (claim + chunks)."""
+    if chunk_ids is not None and len(chunk_ids) != len(evidence_texts):
+        chunk_ids = None
+    numbered = []
+    for i, t in enumerate(evidence_texts):
+        piece = {"id": i, "text": t}
+        if chunk_ids is not None:
+            piece["chunk_id"] = chunk_ids[i]
+        numbered.append(piece)
+
+    # Direct order (winning strategy): explicit instruction at the top
+    parts = [
+        "Classify each evidence piece below as supports, refutes, or not_enough_information "
+        "relative to the claim. "
+    ]
+    if include_relevant_phrase:
+        parts.append(
+            "For supports or refutes, also provide relevant_phrase (a short quote from the evidence) "
+            "and reason (one of the allowed values below). "
+        )
+    elif include_reason:
+        parts.append(
+            "For supports or refutes, also provide reason (one of the allowed values below). "
+        )
+    parts.append(
+        "Return only a valid JSON array of objects with keys: id, stance"
+        + (", relevant_phrase" if include_relevant_phrase else "")
+        + (", reason" if include_reason else "")
+        + ".\n\n"
+    )
+
+    instructions = (
+        "For each evidence piece, respond with a JSON array of objects: "
+        '[{"id": 0, "stance": "supports"}, {"id": 1, "stance": "refutes"}, ...]. '
+        "Use exactly one of: supports, refutes, not_enough_information."
+    )
+    if include_relevant_phrase:
+        instructions += (
+            ' For each piece also include "relevant_phrase": a short quote or phrase from '
+            "that evidence text that is most relevant to the claim. "
+            "When stance is \"supports\" or \"refutes\", relevant_phrase is required (non-empty). "
+            "When stance is \"not_enough_information\", use empty string for relevant_phrase. "
+            "If the link to the claim is unclear, you may use not_enough_information (with empty relevant_phrase)."
+        )
+    if include_reason:
+        reasons_str = ", ".join(f'"{r}"' for r in EVIDENCE_CLASSIFIER_REASONS)
+        instructions += (
+            ' When stance is "supports" or "refutes", include "reason" with exactly one of: '
+            f"{reasons_str}. "
+            "(same_number: evidence gives same number/finding; higher_number/smaller_number: "
+            "claim implies a quantity, evidence gives higher/lower value; contradiction: evidence "
+            "directly contradicts; partial_or_qualification: partial support/contradiction or "
+            "qualification; different_scope_or_timeframe: different region, period, or definition.) "
+            "When stance is \"not_enough_information\", use empty string for reason."
+        )
+
+    payload = {
+        "claim": claim,
+        "evidence_pieces": numbered,
+        "instructions": instructions,
+    }
+    direct_order = "".join(parts)
+    payload_str = json.dumps(payload, indent=2, ensure_ascii=False)
+    return direct_order + payload_str
+
+
+# Retry format instruction for advocates using the full SF label set
+SPECTRUM_ADVOCATE_VERDICT_FORMAT = (
+    "Respond with exactly one verdict in double parentheses. "
+    "Choose from: "
+    + ", ".join(f"(({c}))" for c in SPECTRUM_CATEGORIES)
+    + ". "
+    "Put your reasoning first, then the verdict at the very end."
+)
+
+# When mediator will see advocate proof: ask advocate to pick chunks that support their verdict
+SPECTRUM_ADVOCATE_SELECT_CHUNKS_INSTRUCTION = (
+    "After your verdict, list the chunk IDs (up to 3) that best support your verdict. "
+    "Use the chunk_id values from the evidence. Format exactly: Selected chunks: <id1>, <id2>, <id3>. "
+    "Pick chunks that provide the strongest evidence for the verdict you chose."
+)
+
+# Advocate output: one label + weighted distribution (model provides both)
+SPECTRUM_ADVOCATE_VERDICT_FORMAT_LABEL_AND_WEIGHTS = (
+    "Respond with: (1) your reasoning, (2) exactly one verdict in double parentheses, "
+    "and (3) a JSON object of weights over the same categories that sum to 1.0. "
+    "Verdict choices: " + ", ".join(f"(({c}))" for c in SPECTRUM_CATEGORIES) + ". "
+    "After the verdict, output a JSON object with keys: "
+    + ", ".join(SPECTRUM_CATEGORIES)
+    + " and non-negative values summing to 1.0. Put reasoning first, then verdict, then JSON."
+)
+
+# Advocate output: weighted distribution only (we derive primary by argmax)
+SPECTRUM_ADVOCATE_VERDICT_FORMAT_WEIGHTS_ONLY = (
+    "Respond with: (1) your reasoning, then (2) a JSON object whose keys are exactly: "
+    + ", ".join(SPECTRUM_CATEGORIES)
+    + ". "
+    "The values must be non-negative numbers that sum to 1.0 (your confidence per category). "
+    "Do not output a single verdict in parentheses; output only reasoning and the JSON weights."
+)
+
+# Instruction for the mediator to output a JSON object with weights (sum to 1)
+SPECTRUM_VERDICT_FORMAT = (
+    "Provide a JSON object whose keys are exactly these category names (use underscores): "
+    + ", ".join(SPECTRUM_CATEGORIES)
+    + ". "
+    "The values must be non-negative numbers that sum to 1.0. "
+    "You may include a short explanation before or after the JSON. Output only valid JSON for the weights."
+)
+
+
+# ---------------------------------------------------------------------------
+# Advocate primer — replaces the generic advocate_primer for Spectrum.
+# Explains classified evidence AND the Science Feedback verdict scale.
+# ---------------------------------------------------------------------------
+spectrum_advocate_primer = dedent("""\
+You are a scientific fact-checking Advocate with expertise in climate change,
+climate science, environmental science, physics, and energy science.
+
+## Your task
+Evaluate a claim based SOLELY on the provided evidence and select the single
+most appropriate verdict from the Science Feedback claim review scale.
+
+## Understanding the evidence you receive
+Each evidence piece has been pre-classified with a stance:
+- "supports"                — evidence directly consistent with the claim
+- "refutes"                 — evidence contradicts the claim
+- "not_enough_information"  — evidence is irrelevant or too vague
+
+Use these stance labels to focus your analysis: weigh supporting and refuting
+evidence, and disregard pieces marked as not_enough_information unless they
+add indirect context.
+
+## Science Feedback verdict scale
+Science Feedback distinguishes between two types of claims:
+
+A) **Statements of fact** — rated on the ACCURATE / INACCURATE axis:
+   Does the statement match available data and observations?
+   - accurate            (Very High) — fully consistent with data, no missing context
+   - mostly_accurate     (High)      — largely correct, needs minor clarification
+   - inaccurate          (Very Low)  — directly contradicts available data
+
+B) **Explanations, hypotheses, or theories** — rated on the CORRECT / INCORRECT axis:
+   Has the explanation been well-tested and confirmed by observations?
+   - correct             (Very High) — well-tested, predictions confirmed
+   - mostly_correct      (High)      — well-tested, slightly overstated confidence
+   - correct_but         (Neutral)   — correct with an unstated caveat
+   - partially_correct   (Neutral)   — significantly overstates confidence
+   - incorrect           (Very Low)  — predictions invalidated by observations
+
+C) **Cross-cutting issues** (apply to both types):
+   - lacks_context       (Neutral)   — omits observations/explanations that change the takeaway
+   - imprecise           (Neutral)   — ill-defined terms, ambiguous meaning
+   - unsupported         (Low)       — no adequate reference or evidence
+   - misleading          (Low)       — element of truth but false overall impression
+   - flawed_reasoning    (Low/Issue) — conclusion does not follow from premises
+
+D) **Insufficient evidence**:
+   - not_enough_information — the provided evidence is insufficient to assess the claim
+
+First determine whether the claim is a **statement of fact** or an
+**explanation/theory**, then choose the verdict that best matches the evidence.
+
+## Response format
+Provide a concise reasoning tied to the evidence, then your verdict in double
+parentheses at the very end.  Example:
+
+"The claim overstates the rate of warming reported in IPCC AR6. ((mostly_accurate))"
+
+Choose EXACTLY ONE verdict from the label_options provided.
+""")
+
+
+# ---------------------------------------------------------------------------
+# Mediator — lead fact-checker; picks exactly one of the 14 labels (no distribution).
+# When mediator_mode is "formula", the strategy uses combine_advocate_weights_formula
+# and does not call the mediator LLM.
+# ---------------------------------------------------------------------------
+SPECTRUM_MEDIATOR_LABELS_LIST = ", ".join(SPECTRUM_CATEGORIES)
+
+SPECTRUM_MEDIATOR_VERDICT_FORMAT_INSTRUCTION = (
+    f"Pick exactly one of these labels: {SPECTRUM_MEDIATOR_LABELS_LIST}. "
+    "Output your final verdict as that single label in double parentheses, e.g. ((inaccurate)) or ((not_enough_information))."
+)
+
+SPECTRUM_MEDIATOR_USER_MESSAGE_SUFFIX = (
+    "\n\nPick exactly one of the 14 labels above and provide your final verdict as ((label)), e.g. ((inaccurate))."
+)
+
+spectrum_mediator_primer = dedent("""\
+You are a lead fact checker, receiving an assessment of the following claim
+from one or more senior fact checkers (advocates). You will see their verdict(s)
+and reasoning.
+
+If multiple advocates disagree, your role is to come up with the best verdict.
+If there is consensus or just one advocate, your only task is to pick the single
+most likely verdict you see. If you see an obvious mistake, you may correct it.
+Provide brief reasoning.
+
+You must pick exactly one of the 14 Science Feedback verdict labels and output
+it in double parentheses, e.g. ((inaccurate)) or ((mostly_accurate)).
+Do not output a distribution or JSON — only one label in (( )) format.
+""")

--- a/factchecker/experiments/advocate_mediator_climatefeedback_spectrum/analyze_spectrum_results.py
+++ b/factchecker/experiments/advocate_mediator_climatefeedback_spectrum/analyze_spectrum_results.py
@@ -1,0 +1,66 @@
+"""
+Re-run analysis on an existing Spectrum results CSV (entry point from experiments).
+
+Business logic in factchecker.utils.spectrum_analysis.
+Canonical CLI: python -m factchecker.tools.analyze_spectrum_results
+
+Usage:
+  python -m factchecker.experiments.advocate_mediator_climatefeedback_spectrum.analyze_spectrum_results
+  python -m factchecker.experiments.advocate_mediator_climatefeedback_spectrum.analyze_spectrum_results --results path/to/spectrum_claims_results_*.csv
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from factchecker.utils.spectrum_analysis import (
+    find_latest_spectrum_results_csv,
+    run_spectrum_analysis,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Analyze existing Spectrum results CSV (weighted metrics, optional classification report)."
+    )
+    parser.add_argument(
+        "--results",
+        default=None,
+        help="Path to spectrum_claims_results_*.csv. If omitted, uses most recent in experiments/results/.",
+    )
+    args = parser.parse_args()
+
+    if args.results:
+        path = Path(args.results)
+        if not path.exists():
+            print(f"Error: File not found: {path}", file=sys.stderr)
+            sys.exit(1)
+        csv_path = str(path)
+    else:
+        latest = find_latest_spectrum_results_csv()
+        if latest is None:
+            print(
+                "Error: No spectrum_claims_results_*.csv found. Pass --results path/to/file.csv",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        csv_path = str(latest)
+
+    result = run_spectrum_analysis(csv_path)
+
+    if result.error:
+        print(f"Error: {result.error}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Loaded {result.n_rows} rows from {csv_path}\n")
+
+    if result.classification_report:
+        print("Classification Metrics (primary verdict vs true):")
+        print(result.classification_report)
+
+    if result.weighted_metrics_text:
+        print(result.weighted_metrics_text)
+
+
+if __name__ == "__main__":
+    main()

--- a/factchecker/experiments/advocate_mediator_climatefeedback_spectrum/radar_chart.py
+++ b/factchecker/experiments/advocate_mediator_climatefeedback_spectrum/radar_chart.py
@@ -1,0 +1,134 @@
+"""
+Radar chart visualization for weighted verdict distribution (Spectrum experiment).
+"""
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+from factchecker.experiments.advocate_mediator_climatefeedback_spectrum.advocate_mediator_climatefeedback_spectrum_prompts import (
+    SPECTRUM_CATEGORIES,
+)
+
+
+def _get_weights_dict(weighted_verdict: str) -> Optional[Dict[str, float]]:
+    """Parse weighted_verdict (JSON string or raw) to dict of category -> weight. Returns None if invalid."""
+    if not weighted_verdict or not weighted_verdict.strip():
+        return None
+    s = weighted_verdict.strip()
+    if not s.startswith("{"):
+        return None
+    try:
+        d = json.loads(s)
+        if not isinstance(d, dict):
+            return None
+        out = {}
+        for c in SPECTRUM_CATEGORIES:
+            out[c] = float(d.get(c, 0.0))
+        return out
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+
+
+def plot_radar(
+    weights: Dict[str, float],
+    output_path: str,
+    title: str = "Verdict spectrum",
+) -> bool:
+    """
+    Plot a single radar chart for one weight distribution.
+    Returns True if plotted, False if matplotlib unavailable or weights invalid.
+    """
+    try:
+        import math
+        import matplotlib.pyplot as plt
+        import numpy as np
+    except ImportError:
+        logger.warning("matplotlib not available; skipping radar chart.")
+        return False
+
+    categories = [c.replace("_", " ").title() for c in SPECTRUM_CATEGORIES]
+    values = [weights.get(c_key, 0.0) for c_key in SPECTRUM_CATEGORIES]
+    n = len(categories)
+    angles = [2 * math.pi * i / n for i in range(n)]
+    values += values[:1]
+    angles += angles[:1]
+
+    fig, ax = plt.subplots(figsize=(8, 8), subplot_kw=dict(projection="polar"))
+    ax.plot(angles, values, "o-", linewidth=2, label="Weights")
+    ax.fill(angles, values, alpha=0.25)
+    ax.set_xticks(angles[:-1])
+    ax.set_xticklabels(categories, size=9)
+    ax.set_ylim(0, 1)
+    ax.set_title(title, size=12, pad=20)
+    ax.grid(True)
+    plt.tight_layout()
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close()
+    logger.info("Radar chart saved to %s", output_path)
+    return True
+
+
+def plot_radar_summary(
+    weighted_verdicts: List[str],
+    output_path: str,
+    title: str = "Mean verdict spectrum (all claims)",
+) -> bool:
+    """
+    Plot a single radar chart of mean weights across all claims.
+    Returns True if plotted, False otherwise.
+    """
+    try:
+        import math
+        import matplotlib.pyplot as plt
+        import numpy as np
+    except ImportError:
+        logger.warning("matplotlib not available; skipping radar summary chart.")
+        return False
+
+    dicts = [_get_weights_dict(w) for w in weighted_verdicts]
+    dicts = [d for d in dicts if d is not None]
+    if not dicts:
+        logger.warning("No valid weighted verdicts for radar summary.")
+        return False
+
+    mean_weights = {}
+    for c in SPECTRUM_CATEGORIES:
+        mean_weights[c] = sum(d.get(c, 0.0) for d in dicts) / len(dicts)
+
+    return plot_radar(mean_weights, output_path, title=title)
+
+
+def generate_radar_charts(
+    weighted_verdicts: List[str],
+    output_dir: str = "experiments/results/spectrum_radar",
+    per_claim: bool = True,
+    summary: bool = True,
+) -> List[str]:
+    """
+    Generate radar charts for weighted verdicts.
+    If per_claim, one chart per claim (claim index in filename).
+    If summary, one chart of mean weights.
+    Returns list of saved file paths.
+    """
+    saved: List[str] = []
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    if summary and weighted_verdicts:
+        path = str(Path(output_dir) / "spectrum_summary.png")
+        if plot_radar_summary(weighted_verdicts, path, title="Mean verdict spectrum (all claims)"):
+            saved.append(path)
+
+    if per_claim:
+        for i, wv in enumerate(weighted_verdicts):
+            d = _get_weights_dict(wv)
+            if d is None:
+                continue
+            path = str(Path(output_dir) / f"spectrum_claim_{i}.png")
+            if plot_radar(d, path, title=f"Verdict spectrum (claim {i})"):
+                saved.append(path)
+
+    return saved

--- a/factchecker/experiments/advocate_mediator_climatefeedback_spectrum/run_spectrum_comparison.py
+++ b/factchecker/experiments/advocate_mediator_climatefeedback_spectrum/run_spectrum_comparison.py
@@ -1,0 +1,227 @@
+"""
+Compare two mediator configurations on the same claims:
+
+1. **Formula run**: Advocate outputs weights only → mediator combines by formula (average + argmax), no LLM.
+2. **LLM + evidence run**: Advocate outputs label + weights → mediator is LLM and also sees the most
+   relevant supporting/refuting chunks.
+
+Both runs report normalized metrics (level 2: correct/incorrect; level 5: five categories) for comparison.
+"""
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from llama_index.core import Settings
+from tqdm import tqdm
+
+from factchecker.experiments.advocate_mediator_climatefeedback.advocate_mediator_climatefeedback import (
+    setup_sources,
+)
+from factchecker.experiments.advocate_mediator_climatefeedback_spectrum.advocate_mediator_climatefeedback_spectrum import (
+    EXPERIMENT_PARAMS,
+    _cluster_verdict_for_metrics,
+    _primary_verdict_from_final,
+    _spectrum_verdict_mapper_predicted,
+    _spectrum_verdict_mapper_true,
+    setup_strategy,
+)
+from factchecker.utils.experiment_utils import collect_evaluation_results
+from factchecker.utils.climatefeedback_utils import (
+    sample_climatefeedback_claims,
+)
+from factchecker.utils.experiment_utils import (
+    configure_logging,
+    initialize_results_collectors,
+    save_results,
+    show_evaluation_errors,
+    verify_environment,
+)
+from factchecker.utils.metrics import calculate_classification_metrics
+
+logger = logging.getLogger(__name__)
+
+
+def _run_one(
+    run_name: str,
+    params: Dict[str, Any],
+    sampled_claims,
+    downloaded_files: Optional[List[str]] = None,
+):
+    """Run one configuration; return collectors and errors."""
+    strategy = setup_strategy(params=params, downloaded_files=downloaded_files)
+    num_advocates = len(strategy.advocate_steps)
+    collectors = initialize_results_collectors(num_advocates)
+    collectors["weighted_verdicts"] = []
+    collectors["advocate_evidence_metadata"] = [[] for _ in range(num_advocates)]
+    errors: List[Dict[str, Any]] = []
+
+    for idx, row in tqdm(
+        sampled_claims.iterrows(),
+        total=len(sampled_claims),
+        desc=f"{run_name}: Evaluating claims",
+    ):
+        claim_text = row["Claim"]
+        true_label = row["Climate Feedback"]
+        try:
+            (
+                final_verdict,
+                verdicts,
+                reasonings,
+                evidence_metadata_per_advocate,
+                advocate_weights_per_advocate,
+            ) = strategy.evaluate_claim(claim_text)
+            primary_verdict = _primary_verdict_from_final(final_verdict)
+            collectors = collect_evaluation_results(
+                collectors,
+                (true_label, primary_verdict, verdicts, reasonings),
+                num_advocates=len(verdicts) if not collectors["advocate_evidences"] else None,
+                claim_index=idx,
+            )
+            collectors["weighted_verdicts"].append(final_verdict)
+            for i in range(num_advocates):
+                meta = (
+                    evidence_metadata_per_advocate[i]
+                    if evidence_metadata_per_advocate and i < len(evidence_metadata_per_advocate)
+                    else None
+                )
+                collectors["advocate_evidence_metadata"][i].append(meta if meta else [])
+            if "advocate_weighted_verdicts" in collectors:
+                for i in range(num_advocates):
+                    w = (
+                        advocate_weights_per_advocate[i]
+                        if advocate_weights_per_advocate and i < len(advocate_weights_per_advocate)
+                        else None
+                    )
+                    collectors["advocate_weighted_verdicts"][i].append(
+                        json.dumps(w) if isinstance(w, dict) else w
+                    )
+        except Exception as e:
+            logger.error("Error processing claim %s (%s): %s", idx, run_name, e)
+            errors.append({
+                "claim_index": idx,
+                "error_type": type(e).__name__,
+                "error_message": str(e),
+                "claim_preview": (claim_text[:80] + "...") if len(claim_text) > 80 else claim_text,
+            })
+    return collectors, errors
+
+
+def main(experiment_options: Optional[Dict[str, Any]] = None):
+    """Run both configurations on the same claims and compare normalized metrics."""
+    configure_logging()
+    params = {**EXPERIMENT_PARAMS, **(experiment_options or {})}
+    params["total_samples"] = params.get("total_samples", 10)
+
+    verify_environment()
+    downloaded_files = setup_sources(params=params)
+    Settings.chunk_size = params["chunk_size"]
+    Settings.chunk_overlap = params["chunk_overlap"]
+
+    logger.info("Sampling claims once for both runs...")
+    sampled_claims = sample_climatefeedback_claims(
+        csv_path=params["dataset_path"],
+        total_samples=params["total_samples"],
+        correct_ratio=params["correct_ratio"],
+    )
+
+    # Run 1: weights from advocate → mediator = formula (no LLM)
+    run1_params = {
+        **params,
+        "advocate_output_mode": "weights_only",
+        "mediator_mode": "formula",
+    }
+    logger.info("Run 1: advocate weights_only + mediator formula")
+    collectors1, errors1 = _run_one("formula", run1_params, sampled_claims, downloaded_files)
+    show_evaluation_errors(errors1, total_claims=len(sampled_claims))
+
+    # Run 2: label + weights from advocate → mediator LLM with evidence summary
+    run2_params = {
+        **params,
+        "advocate_output_mode": "label_and_weights",
+        "mediator_mode": "llm_with_evidence",
+    }
+    logger.info("Run 2: advocate label_and_weights + mediator llm_with_evidence")
+    collectors2, errors2 = _run_one("llm_with_evidence", run2_params, sampled_claims, downloaded_files)
+    show_evaluation_errors(errors2, total_claims=len(sampled_claims))
+
+    # Align results by claim index (only claims that succeeded in both runs)
+    indices1 = set(collectors1.get("claim_indices", []))
+    indices2 = set(collectors2.get("claim_indices", []))
+    common_indices = sorted(indices1 & indices2)
+    if not common_indices:
+        logger.warning("No claims succeeded in both runs; cannot compare.")
+        return
+
+    # Build aligned lists for common claims
+    pos1 = {idx: i for i, idx in enumerate(collectors1.get("claim_indices", []))}
+    pos2 = {idx: i for i, idx in enumerate(collectors2.get("claim_indices", []))}
+    true_labels = []
+    run1_primaries = []
+    run2_primaries = []
+    claims_subset = []
+    for idx in common_indices:
+        i1, i2 = pos1[idx], pos2[idx]
+        true_labels.append(collectors1["true_labels"][i1])
+        run1_primaries.append(collectors1["predicted_results"][i1])
+        run2_primaries.append(collectors2["predicted_results"][i2])
+        claims_subset.append(sampled_claims.loc[idx, "Claim"])
+
+    true_mapped = [_spectrum_verdict_mapper_true(l) for l in true_labels]
+    run1_mapped = [_spectrum_verdict_mapper_predicted(p) for p in run1_primaries]
+    run2_mapped = [_spectrum_verdict_mapper_predicted(p) for p in run2_primaries]
+
+    # Normalized (level 2 and level 5) metrics for each run
+    print("\n" + "=" * 60)
+    print("COMPARISON: Formula vs LLM+evidence (normalized labels)")
+    print("=" * 60)
+
+    for level in (2, 5):
+        level_name = "correct/incorrect (level 2)" if level == 2 else "level-5 categories"
+        true_clustered = [_cluster_verdict_for_metrics(l, level) for l in true_mapped]
+        run1_clustered = [_cluster_verdict_for_metrics(l, level) for l in run1_mapped]
+        run2_clustered = [_cluster_verdict_for_metrics(l, level) for l in run2_mapped]
+
+        m1 = calculate_classification_metrics(true_clustered, run1_clustered, verdict_mapper=None)
+        m2 = calculate_classification_metrics(true_clustered, run2_clustered, verdict_mapper=None)
+
+        print(f"\n--- {level_name} ---")
+        print("Run 1 (formula: advocate weights → average + argmax):")
+        print(m1)
+        print("\nRun 2 (LLM+evidence: advocate label+weights → mediator sees supporting/refuting chunks):")
+        print(m2)
+
+    # Comparison CSV: Claim, True Label, Run1_mediator_primary, Run2_mediator_primary, True_L2, Run1_L2, Run2_L2, True_L5, Run1_L5, Run2_L5
+    import pandas as pd
+
+    true_l2 = [_cluster_verdict_for_metrics(l, 2) for l in true_mapped]
+    true_l5 = [_cluster_verdict_for_metrics(l, 5) for l in true_mapped]
+    run1_l2 = [_cluster_verdict_for_metrics(l, 2) for l in run1_mapped]
+    run1_l5 = [_cluster_verdict_for_metrics(l, 5) for l in run1_mapped]
+    run2_l2 = [_cluster_verdict_for_metrics(l, 2) for l in run2_mapped]
+    run2_l5 = [_cluster_verdict_for_metrics(l, 5) for l in run2_mapped]
+
+    comparison_df = pd.DataFrame({
+        "Claim": claims_subset,
+        "True Label": true_labels,
+        "Run1_mediator_primary": run1_primaries,
+        "Run2_mediator_primary": run2_primaries,
+        "True_L2": true_l2,
+        "Run1_L2": run1_l2,
+        "Run2_L2": run2_l2,
+        "True_L5": true_l5,
+        "Run1_L5": run1_l5,
+        "Run2_L5": run2_l5,
+    })
+    out_path = save_results(
+        comparison_df,
+        base_path="experiments/results",
+        prefix="spectrum_comparison_formula_vs_llm_evidence",
+    )
+    logger.info("Comparison CSV saved to: %s", out_path)
+    print(f"\nComparison saved to: {out_path}")
+    print(f"Compared {len(common_indices)} claims (successful in both runs).")
+
+
+if __name__ == "__main__":
+    main()

--- a/factchecker/experiments/advocate_mediator_climatefeedback_spectrum/run_spectrum_mediator_evidence_comparison.py
+++ b/factchecker/experiments/advocate_mediator_climatefeedback_spectrum/run_spectrum_mediator_evidence_comparison.py
@@ -1,0 +1,152 @@
+"""
+Compare mediator with no evidence vs mediator with 3 advocate-selected supporting chunks.
+
+(a) Mediator sees only verdicts and reasonings (no evidence).
+(b) Mediator sees verdicts, reasonings, and up to 3 chunks the advocate used to support its verdict
+    (supporting chunks only, no contradicting evidence).
+
+Both runs use the same advocate setup and chunk labelling; only what the mediator sees differs.
+"""
+import logging
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+from llama_index.core import Settings
+from tqdm import tqdm
+
+from factchecker.experiments.advocate_mediator_climatefeedback.advocate_mediator_climatefeedback import (
+    setup_sources,
+)
+from factchecker.experiments.advocate_mediator_climatefeedback_spectrum.advocate_mediator_climatefeedback_spectrum import (
+    EXPERIMENT_PARAMS,
+    _cluster_verdict_for_metrics,
+    _spectrum_verdict_mapper_predicted,
+    _spectrum_verdict_mapper_true,
+    evaluate_spectrum_claims,
+    setup_strategy,
+)
+from factchecker.utils.climatefeedback_utils import sample_climatefeedback_claims
+from factchecker.utils.experiment_utils import (
+    configure_logging,
+    save_results,
+    show_evaluation_errors,
+    verify_environment,
+)
+from factchecker.utils.metrics import calculate_classification_metrics
+from sklearn.metrics import accuracy_score
+
+logger = logging.getLogger(__name__)
+
+
+def main(experiment_options: Optional[Dict[str, Any]] = None):
+    """Run (a) mediator no evidence and (b) mediator with 3 supporting chunks; compare on same claims."""
+    configure_logging()
+    params = {**EXPERIMENT_PARAMS, **(experiment_options or {})}
+    params["ablation_compare_chunk_labelling"] = False
+    params["compare_mediator_modes"] = False
+    params["total_samples"] = params.get("total_samples", 10)
+    params["use_evidence_classifier"] = True  # need classified chunks to build advocate proof
+
+    verify_environment()
+    downloaded_files = setup_sources(params=params)
+    Settings.chunk_size = params["chunk_size"]
+    Settings.chunk_overlap = params["chunk_overlap"]
+
+    logger.info("Sampling claims once for both runs...")
+    sampled_claims = sample_climatefeedback_claims(
+        csv_path=params["dataset_path"],
+        total_samples=params["total_samples"],
+        correct_ratio=params["correct_ratio"],
+    )
+    total_claims = len(sampled_claims)
+    parallel_claims = params.get("parallel_claims", 0) or 0
+
+    # Run (a): mediator sees no evidence
+    params_no_evidence = {**params, "mediator_mode": "llm"}
+    strategy_a = setup_strategy(params=params_no_evidence, downloaded_files=downloaded_files)
+    num_advocates = len(strategy_a.advocate_steps)
+    collectors_a, errors_a = evaluate_spectrum_claims(
+        strategy_a, sampled_claims, num_advocates, parallel_claims=parallel_claims
+    )
+    show_evaluation_errors(errors_a, total_claims=total_claims)
+
+    # Run (b): mediator sees only 3 supporting chunks (advocate's proof)
+    params_with_proof = {**params, "mediator_mode": "llm_with_advocate_proof", "mediator_proof_max_chunks": 3}
+    strategy_b = setup_strategy(params=params_with_proof, downloaded_files=downloaded_files)
+    collectors_b, errors_b = evaluate_spectrum_claims(
+        strategy_b, sampled_claims, num_advocates, parallel_claims=parallel_claims
+    )
+    show_evaluation_errors(errors_b, total_claims=total_claims)
+
+    # Align by claim index (only claims that succeeded in both runs)
+    indices_a = set(collectors_a.get("claim_indices", []))
+    indices_b = set(collectors_b.get("claim_indices", []))
+    common_indices = sorted(indices_a & indices_b)
+    if not common_indices:
+        logger.warning("No claims succeeded in both runs; cannot compare.")
+        print("No claims succeeded in both runs; cannot compare.")
+        return
+
+    pos_a = {idx: i for i, idx in enumerate(collectors_a.get("claim_indices", []))}
+    pos_b = {idx: i for i, idx in enumerate(collectors_b.get("claim_indices", []))}
+    true_labels = [collectors_a["true_labels"][pos_a[idx]] for idx in common_indices]
+    run_a_primaries = [collectors_a["predicted_results"][pos_a[idx]] for idx in common_indices]
+    run_b_primaries = [collectors_b["predicted_results"][pos_b[idx]] for idx in common_indices]
+    claims_subset = [sampled_claims.loc[idx, "Claim"] for idx in common_indices]
+
+    true_mapped = [_spectrum_verdict_mapper_true(l) for l in true_labels]
+    run_a_mapped = [_spectrum_verdict_mapper_predicted(p) for p in run_a_primaries]
+    run_b_mapped = [_spectrum_verdict_mapper_predicted(p) for p in run_b_primaries]
+
+    print("\n" + "=" * 60)
+    print("COMPARISON: Mediator (a) no evidence vs (b) 3 advocate-supporting chunks")
+    print("=" * 60)
+
+    for level in (2, 5):
+        level_name = "correct/incorrect (L2)" if level == 2 else "level-5 (L5)"
+        true_c = [_cluster_verdict_for_metrics(l, level) for l in true_mapped]
+        run_a_c = [_cluster_verdict_for_metrics(l, level) for l in run_a_mapped]
+        run_b_c = [_cluster_verdict_for_metrics(l, level) for l in run_b_mapped]
+        acc_a = accuracy_score(true_c, run_a_c)
+        acc_b = accuracy_score(true_c, run_b_c)
+        print(f"\n--- {level_name} ---")
+        print(f"(a) Mediator no evidence:  {acc_a:.2%}")
+        print(f"(b) Mediator 3 supporting chunks: {acc_b:.2%}")
+        m_a = calculate_classification_metrics(true_c, run_a_c, verdict_mapper=None)
+        m_b = calculate_classification_metrics(true_c, run_b_c, verdict_mapper=None)
+        print("\n(a) Full report:")
+        print(m_a)
+        print("\n(b) Full report:")
+        print(m_b)
+
+    true_l2 = [_cluster_verdict_for_metrics(l, 2) for l in true_mapped]
+    true_l5 = [_cluster_verdict_for_metrics(l, 5) for l in true_mapped]
+    run_a_l2 = [_cluster_verdict_for_metrics(l, 2) for l in run_a_mapped]
+    run_a_l5 = [_cluster_verdict_for_metrics(l, 5) for l in run_a_mapped]
+    run_b_l2 = [_cluster_verdict_for_metrics(l, 2) for l in run_b_mapped]
+    run_b_l5 = [_cluster_verdict_for_metrics(l, 5) for l in run_b_mapped]
+
+    comparison_df = pd.DataFrame({
+        "Claim": claims_subset,
+        "True Label": true_labels,
+        "Run_a_mediator_primary_no_evidence": run_a_primaries,
+        "Run_b_mediator_primary_3_supporting_chunks": run_b_primaries,
+        "True_L2": true_l2,
+        "Run_a_L2": run_a_l2,
+        "Run_b_L2": run_b_l2,
+        "True_L5": true_l5,
+        "Run_a_L5": run_a_l5,
+        "Run_b_L5": run_b_l5,
+    })
+    out_path = save_results(
+        comparison_df,
+        base_path="experiments/results",
+        prefix="spectrum_comparison_mediator_no_evidence_vs_3_supporting_chunks",
+    )
+    logger.info("Comparison CSV saved to: %s", out_path)
+    print(f"\nComparison saved to: {out_path}")
+    print(f"Compared {len(common_indices)} claims (successful in both runs).")
+
+
+if __name__ == "__main__":
+    main()

--- a/factchecker/experiments/advocate_mediator_climatefeedback_spectrum/weighted_metrics.py
+++ b/factchecker/experiments/advocate_mediator_climatefeedback_spectrum/weighted_metrics.py
@@ -1,0 +1,115 @@
+"""
+Metrics for weighted verdict distributions (Spectrum experiment).
+
+- Log loss (cross-entropy): uses full distribution; lower is better.
+- Top-k accuracy: true verdict in model's top-k by weight.
+"""
+import json
+import logging
+import math
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+from factchecker.experiments.advocate_mediator_climatefeedback_spectrum.advocate_mediator_climatefeedback_spectrum_prompts import (
+    SPECTRUM_CATEGORIES,
+)
+
+# Avoid log(0)
+_EPS = 1e-10
+
+
+def _parse_weights(weighted_verdict: str) -> Optional[dict]:
+    """Parse weighted_verdict JSON to dict category -> weight. Returns None if invalid."""
+    if not weighted_verdict or not weighted_verdict.strip():
+        return None
+    s = weighted_verdict.strip()
+    if not s.startswith("{"):
+        return None
+    try:
+        d = json.loads(s)
+        if not isinstance(d, dict):
+            return None
+        out = {}
+        for c in SPECTRUM_CATEGORIES:
+            out[c] = float(d.get(c, 0.0))
+        return out
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+
+
+def log_loss(
+    true_labels: List[str],
+    weighted_verdicts: List[str],
+) -> Optional[float]:
+    """
+    Mean cross-entropy loss: -log(p_true) per sample.
+    True label is one-hot; predicted is the weight distribution.
+    Lower is better. Returns None if no valid pairs.
+    """
+    if len(true_labels) != len(weighted_verdicts) or not true_labels:
+        return None
+    total = 0.0
+    count = 0
+    for true, wv in zip(true_labels, weighted_verdicts, strict=True):
+        weights = _parse_weights(wv)
+        if weights is None:
+            # Fallback: treat as one-hot on a single verdict (wv is the verdict string)
+            p_true = 1.0 if true.strip().lower().replace(" ", "_") == wv.strip().lower().replace(" ", "_") else 0.0
+        else:
+            true_norm = true.strip().lower().replace(" ", "_")
+            if true_norm == "not_enough_info":
+                true_norm = "not_enough_information"
+            p_true = weights.get(true_norm, 0.0)
+        p_true = max(p_true, _EPS)
+        total += -math.log(p_true)
+        count += 1
+    return total / count if count else None
+
+
+def top_k_accuracy(
+    true_labels: List[str],
+    weighted_verdicts: List[str],
+    k: int,
+) -> Optional[float]:
+    """
+    Fraction of samples where the true label is in the model's top-k by weight.
+    Returns value in [0, 1] or None if no valid pairs.
+    """
+    if len(true_labels) != len(weighted_verdicts) or not true_labels or k < 1:
+        return None
+    hits = 0
+    for true, wv in zip(true_labels, weighted_verdicts, strict=True):
+        true_norm = true.strip().lower().replace(" ", "_")
+        if true_norm == "not_enough_info":
+            true_norm = "not_enough_information"
+        weights = _parse_weights(wv)
+        if weights is None:
+            # Fallback: single verdict string
+            pred_norm = wv.strip().lower().replace(" ", "_") if wv else ""
+            top_k = [pred_norm] if pred_norm else []
+        else:
+            sorted_cats = sorted(weights.keys(), key=lambda c: weights[c], reverse=True)
+            top_k = sorted_cats[:k]
+        if true_norm in top_k:
+            hits += 1
+    return hits / len(true_labels)
+
+
+def format_weighted_metrics(
+    true_labels: List[str],
+    weighted_verdicts: List[str],
+) -> str:
+    """Compute log loss and top-2/top-3 accuracy and return a formatted string for logging/print."""
+    lines = ["\n--- Weighted distribution metrics ---"]
+    ll = log_loss(true_labels, weighted_verdicts)
+    if ll is not None:
+        lines.append(f"Log loss (cross-entropy): {ll:.4f} (lower is better)")
+    t2 = top_k_accuracy(true_labels, weighted_verdicts, 2)
+    if t2 is not None:
+        lines.append(f"Top-2 accuracy:           {t2:.2%} (true verdict in top-2 by weight)")
+    t3 = top_k_accuracy(true_labels, weighted_verdicts, 3)
+    if t3 is not None:
+        lines.append(f"Top-3 accuracy:           {t3:.2%} (true verdict in top-3 by weight)")
+    lines.append("---")
+    return "\n".join(lines)

--- a/factchecker/experiments/advocate_mediator_climatefeedback_spectrum/weighted_parser.py
+++ b/factchecker/experiments/advocate_mediator_climatefeedback_spectrum/weighted_parser.py
@@ -1,0 +1,268 @@
+"""
+Parser for Spectrum mediator and advocate output: extract JSON weights, markdown-style
+distribution, or ((verdict)) single label. Advocate parsers return (label?, reasoning, weights?).
+With chunk selection: (label?, reasoning, weights?, selected_chunk_ids).
+"""
+import json
+import re
+from typing import List, Optional, Tuple
+
+from factchecker.experiments.advocate_mediator_climatefeedback_spectrum.advocate_mediator_climatefeedback_spectrum_prompts import (
+    SPECTRUM_CATEGORIES,
+)
+
+
+def _normalize_key(key: str) -> str:
+    """Normalize category key to canonical Science Feedback verdict (snake_case)."""
+    k = key.strip().lower().replace(" ", "_").replace("-", "_")
+    if k == "not_enough_info":
+        return "not_enough_information"
+    return k
+
+
+def _parse_markdown_style_weights(text: str) -> Optional[dict]:
+    """
+    Parse lines like "* accurate: 0.00" or "* lacks_context: 0.50" into a weight dict.
+    Many models output a bullet list instead of raw JSON; accept that so we don't lose the distribution.
+    """
+    weights = {}
+    # Match * key: value or * key = value
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or not line.startswith("*"):
+            continue
+        line = line.lstrip("*").strip()
+        m = re.match(r"^([a-z_]+)\s*[:=]\s*([\d.]+)", line, re.I)
+        if m:
+            key = _normalize_key(m.group(1))
+            try:
+                val = float(m.group(2))
+            except ValueError:
+                continue
+            if key in SPECTRUM_CATEGORIES:
+                weights[key] = val
+    if not weights:
+        return None
+    return _normalize_weights_dict(weights)
+
+
+def _normalize_weights_dict(weights: dict) -> dict:
+    """Ensure all SPECTRUM_CATEGORIES present and values sum to 1."""
+    for c in SPECTRUM_CATEGORIES:
+        if c not in weights:
+            weights[c] = 0.0
+    total = sum(weights.values())
+    if total > 0:
+        for c in weights:
+            weights[c] = weights[c] / total
+    return weights
+
+
+def _extract_weights_from_text(text: str) -> Optional[dict]:
+    """Extract a normalized weight dict from text (JSON or markdown-style). Returns None if none found."""
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        try:
+            raw = json.loads(text[start : end + 1])
+            if not isinstance(raw, dict):
+                return None
+            weights = {}
+            for k, v in raw.items():
+                norm = _normalize_key(k)
+                if norm in SPECTRUM_CATEGORIES:
+                    try:
+                        weights[norm] = float(v)
+                    except (TypeError, ValueError):
+                        weights[norm] = 0.0
+            if weights:
+                return _normalize_weights_dict(weights)
+        except (json.JSONDecodeError, ValueError):
+            pass
+    md_weights = _parse_markdown_style_weights(text)
+    return md_weights
+
+
+def _extract_selected_chunk_ids(text: str) -> List[str]:
+    """
+    Extract chunk IDs from a line like "Selected chunks: id1, id2, id3" or
+    "Selected chunk IDs: id1; id2". Returns list of stripped non-empty IDs.
+    """
+    ids: List[str] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if "selected chunk" not in line.lower():
+            continue
+        idx = line.lower().find("selected chunk")
+        rest = line[idx:]
+        colon = rest.find(":")
+        if colon == -1:
+            continue
+        rest = rest[colon + 1 :].strip()
+        for part in re.split(r"[,;\n]", rest):
+            pid = part.strip()
+            if pid:
+                ids.append(pid)
+        break
+    return ids[:10]  # cap at 10
+
+
+def _extract_advocate_label_and_reasoning(text: str) -> Tuple[Optional[str], str]:
+    """Extract ((category)) label (if any) and reasoning. Label normalized to snake_case and must be in SPECTRUM_CATEGORIES."""
+    match = re.search(r"\(\(\s*([^)]+)\s*\)\)", text)
+    label = None
+    if match:
+        raw = match.group(1).strip().lower().replace(" ", "_").replace("-", "_")
+        if raw == "not_enough_info":
+            raw = "not_enough_information"
+        if raw in SPECTRUM_CATEGORIES:
+            label = raw
+    reasoning = text
+    if match:
+        reasoning = (text[: match.start()].strip() + " " + text[match.end() :].strip()).strip()
+    return label, reasoning
+
+
+def parse_mediator_single_label(response_content: str) -> Optional[str]:
+    """
+    Parse mediator response when output is a single label: extract ((label)) and return
+    the matching SPECTRUM_CATEGORIES entry, or None if not found or not in categories.
+    """
+    text = (response_content or "").strip()
+    match = re.search(r"\(\(\s*([^)]+)\s*\)\)", text)
+    if not match:
+        return None
+    raw = match.group(1).strip()
+    norm = _normalize_key(raw)
+    if norm in SPECTRUM_CATEGORIES:
+        return norm
+    return None
+
+
+def parse_advocate_response_label_and_weights(response_content: str) -> Optional[Tuple[str, str, dict]]:
+    """
+    Parse advocate response when mode is label_and_weights: extract single label, reasoning, and weight dict.
+    Returns (label, reasoning, weights) or None if required parts missing (label and weights both required).
+    """
+    text = response_content.strip()
+    label, reasoning = _extract_advocate_label_and_reasoning(text)
+    weights = _extract_weights_from_text(text)
+    if label is not None and weights is not None:
+        return (label, reasoning, weights)
+    return None
+
+
+def parse_advocate_response_label_only_with_chunk_selection(
+    response_content: str,
+) -> Optional[Tuple[str, str, None, List[str]]]:
+    """
+    Parse advocate response when we ask for verdict + selected chunk IDs (label_only mode).
+    Returns (label, reasoning, None, selected_chunk_ids) or None if label missing.
+    selected_chunk_ids may be empty if the advocate did not list any.
+    """
+    text = (response_content or "").strip()
+    label, reasoning = _extract_advocate_label_and_reasoning(text)
+    if label is None:
+        return None
+    selected = _extract_selected_chunk_ids(text)
+    return (label, reasoning, None, selected)
+
+
+def parse_advocate_response_weights_only(response_content: str) -> Optional[Tuple[None, str, dict]]:
+    """
+    Parse advocate response when mode is weights_only: extract reasoning and weight dict only.
+    Returns (None, reasoning, weights) or None if weights missing.
+    """
+    text = response_content.strip()
+    weights = _extract_weights_from_text(text)
+    if weights is None:
+        return None
+    # Reasoning: text before the JSON block, or full text if no JSON
+    start = text.find("{")
+    if start != -1:
+        reasoning = text[:start].strip()
+    else:
+        reasoning = text
+    return (None, reasoning, weights)
+
+
+def parse_weighted_response(response_content: str) -> Optional[str]:
+    """
+    Parse mediator response: if it contains a valid JSON object of category weights,
+    return json.dumps(weights) string. Also accepts markdown-style "* key: value" lists.
+    Otherwise try ((correct)) / ((incorrect)) / ((not_enough_information))
+    and return that verdict string (normalized). Returns None if unparseable.
+
+    Returns:
+        Either a JSON string of weights (for spectrum) or a single verdict string (fallback).
+    """
+    text = response_content.strip()
+
+    # 1. Try to extract JSON object
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        try:
+            json_str = text[start : end + 1]
+            raw = json.loads(json_str)
+            if not isinstance(raw, dict):
+                raise ValueError("Not a dict")
+            weights = {}
+            for k, v in raw.items():
+                norm = _normalize_key(k)
+                if norm in SPECTRUM_CATEGORIES:
+                    try:
+                        weights[norm] = float(v)
+                    except (TypeError, ValueError):
+                        weights[norm] = 0.0
+            for c in SPECTRUM_CATEGORIES:
+                if c not in weights:
+                    weights[c] = 0.0
+            total = sum(weights.values())
+            if total > 0:
+                for c in weights:
+                    weights[c] = weights[c] / total
+            return json.dumps(weights)
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    # 2. Try markdown-style "* key: value" lines (so we don't lose the distribution on retry)
+    md_weights = _parse_markdown_style_weights(text)
+    if md_weights is not None:
+        return json.dumps(md_weights)
+
+    # 3. Fallback: ((correct)), ((incorrect)), ((not_enough_information))
+    match = re.search(r"\(\(\s*([^)]+)\s*\)\)", text)
+    if match:
+        verdict = match.group(1).strip().upper().replace(" ", "_")
+        if verdict in ("CORRECT", "INCORRECT", "NOT_ENOUGH_INFORMATION"):
+            return verdict
+        if verdict in ("NOT_ENOUGH_INFO", "NEI"):
+            return "NOT_ENOUGH_INFORMATION"
+    return None
+
+
+def combine_advocate_weights_formula(
+    advocate_weights_per_advocate: List[Optional[dict]],
+) -> Tuple[str, dict]:
+    """
+    Combine advocate weight distributions by averaging. Final verdict = argmax of averaged weights.
+
+    Args:
+        advocate_weights_per_advocate: List of weight dicts (one per advocate); entries can be None.
+
+    Returns:
+        (primary_verdict, combined_weights_dict). combined_weights_dict is normalized (sum=1).
+        If no valid weights, returns ("not_enough_information", {not_enough_information: 1.0, ...}).
+    """
+    valid = [w for w in advocate_weights_per_advocate if w and isinstance(w, dict) and len(w) > 0]
+    if not valid:
+        out = {c: 0.0 for c in SPECTRUM_CATEGORIES}
+        out["not_enough_information"] = 1.0
+        return "not_enough_information", out
+    combined = {}
+    for c in SPECTRUM_CATEGORIES:
+        combined[c] = sum(w.get(c, 0.0) for w in valid) / len(valid)
+    combined = _normalize_weights_dict(combined)
+    primary = max(combined, key=combined.get)
+    return primary, combined

--- a/factchecker/prompts/advocate_prompts.py
+++ b/factchecker/prompts/advocate_prompts.py
@@ -77,3 +77,76 @@ def get_default_user_prompt(
 
     # Return as formatted JSON string for better readability
     return json.dumps(input_data, indent=4, ensure_ascii=False)
+
+
+def chunk_stats_from_classified(classified_evidence: list[dict]) -> dict:
+    """
+    Compute counts from classified evidence so NIN and chunks without relevant_phrase are tracked.
+    Returns dict with n_supports, n_refutes, n_nin, n_with_relevant_phrase, n_without_relevant_phrase, n_total.
+    """
+    n_supports = n_refutes = n_nin = n_with_phrase = 0
+    for c in classified_evidence or []:
+        if not isinstance(c, dict):
+            continue
+        stance = (c.get("stance") or "").strip().lower()
+        if stance == "supports":
+            n_supports += 1
+        elif stance == "refutes":
+            n_refutes += 1
+        else:
+            n_nin += 1
+        if (c.get("relevant_phrase") or "").strip():
+            n_with_phrase += 1
+    n_total = n_supports + n_refutes + n_nin
+    n_without_phrase = n_total - n_with_phrase
+    return {
+        "n_supports": n_supports,
+        "n_refutes": n_refutes,
+        "n_nin": n_nin,
+        "n_with_relevant_phrase": n_with_phrase,
+        "n_without_relevant_phrase": n_without_phrase,
+        "n_total": n_total,
+    }
+
+
+def get_classified_evidence_user_prompt(
+        claim: str,
+        classified_evidence: list[dict],
+        label_options: dict[str, str],
+        evidence_display_mode: str = "full",
+        chunk_stats: dict | None = None,
+    ) -> str:
+    """
+    User prompt variant that includes pre-classified evidence (with stance labels).
+
+    Args:
+        claim: The claim to be fact-checked.
+        classified_evidence: List of dicts with text, stance, optional relevant_phrase, chunk_id, reason.
+        label_options: Dict mapping verdict labels to their Science Feedback descriptions.
+        evidence_display_mode: "full" = pass full chunk text; "relevant_only" = pass only relevant_phrase
+            or "[no specific relevant part]" so chunks without a phrase and NIN chunks still appear with a placeholder.
+        chunk_stats: Optional dict from chunk_stats_from_classified(); added as chunk_summary so model sees counts.
+
+    Returns:
+        JSON-formatted string for the advocate LLM.
+    """
+    display = classified_evidence
+    if evidence_display_mode == "relevant_only" and classified_evidence:
+        display = []
+        for c in classified_evidence:
+            copy = dict(c)
+            phrase = (c.get("relevant_phrase") or "").strip()
+            copy["text"] = phrase if phrase else "[no specific relevant part]"
+            display.append(copy)
+    input_data = {
+        "claim": claim,
+        "classified_evidence": display,
+        "label_options": label_options,
+    }
+    if chunk_stats:
+        input_data["chunk_summary"] = (
+            f"Chunks: {chunk_stats.get('n_supports', 0)} supporting, {chunk_stats.get('n_refutes', 0)} refuting, "
+            f"{chunk_stats.get('n_nin', 0)} NIN; {chunk_stats.get('n_with_relevant_phrase', 0)} with highlighted relevant phrase, "
+            f"{chunk_stats.get('n_without_relevant_phrase', 0)} without."
+        )
+    return json.dumps(input_data, indent=4, ensure_ascii=False)

--- a/factchecker/prompts/evidence_classifier_prompts.py
+++ b/factchecker/prompts/evidence_classifier_prompts.py
@@ -1,0 +1,65 @@
+"""
+Prompts for the EvidenceClassifierStep.
+
+Classifies each retrieved evidence chunk as supports / refutes / not_enough_information
+relative to a given claim. Single LLM call for all chunks.
+"""
+import json
+from textwrap import dedent
+from typing import Optional
+
+EVIDENCE_STANCES = ("supports", "refutes", "not_enough_information")
+
+EVIDENCE_CLASSIFIER_SYSTEM_PROMPT = dedent("""\
+You are a scientific evidence classifier. Your sole task is to determine
+the relationship between a claim and individual pieces of evidence.
+
+For each evidence piece you must assign exactly one stance:
+- "supports"                — the evidence directly supports or is consistent with the claim
+- "refutes"                 — the evidence contradicts or is inconsistent with the claim
+- "not_enough_information"  — the evidence is irrelevant or too vague to support or refute the claim
+
+You may use not_enough_information whenever the evidence does not clearly support or refute the claim.
+
+Rules:
+1. Judge each evidence piece independently.
+2. Do NOT evaluate whether the claim itself is true — only whether the evidence relates to it.
+3. Base your classification solely on the text provided; do not add external knowledge.
+4. Respond with ONLY a valid JSON array (no commentary before or after).
+""")
+
+
+def get_evidence_classifier_user_prompt(
+    claim: str,
+    evidence_texts: list[str],
+    include_relevant_phrase: bool = False,
+    chunk_ids: Optional[list[str]] = None,
+) -> str:
+    """Build the user prompt containing the claim and numbered evidence pieces."""
+    if chunk_ids is not None and len(chunk_ids) != len(evidence_texts):
+        chunk_ids = None
+    numbered = []
+    for i, t in enumerate(evidence_texts):
+        piece = {"id": i, "text": t}
+        if chunk_ids is not None:
+            piece["chunk_id"] = chunk_ids[i]
+        numbered.append(piece)
+    instructions = (
+        "For each evidence piece, respond with a JSON array of objects: "
+        '[{"id": 0, "stance": "supports"}, {"id": 1, "stance": "refutes"}, ...]. '
+        "Use exactly one of: supports, refutes, not_enough_information."
+    )
+    if include_relevant_phrase:
+        instructions += (
+            ' For each piece also include "relevant_phrase": a short quote or phrase from '
+            "that evidence text that is most relevant to the claim. "
+            "When stance is \"supports\" or \"refutes\", relevant_phrase is required (non-empty). "
+            "When stance is \"not_enough_information\", use empty string for relevant_phrase. "
+            "If the link to the claim is unclear, you may use not_enough_information (with empty relevant_phrase)."
+        )
+    payload = {
+        "claim": claim,
+        "evidence_pieces": numbered,
+        "instructions": instructions,
+    }
+    return json.dumps(payload, indent=2, ensure_ascii=False)

--- a/factchecker/steps/advocate.py
+++ b/factchecker/steps/advocate.py
@@ -1,12 +1,17 @@
 import logging
-from typing import Callable, Optional, Tuple
+from typing import Callable, List, Optional, Tuple, Union
 
 from llama_index.core.llms import ChatMessage
 
 from factchecker.config.config import DEFAULT_LABEL_OPTIONS
 from factchecker.core.llm import load_llm
 from factchecker.datastructures import LabelOption
-from factchecker.prompts.advocate_prompts import get_default_system_prompt, get_default_user_prompt
+from factchecker.prompts.advocate_prompts import (
+    chunk_stats_from_classified,
+    get_classified_evidence_user_prompt,
+    get_default_system_prompt,
+    get_default_user_prompt,
+)
 from factchecker.retrieval.abstract_retriever import AbstractRetriever
 from factchecker.steps.evidence import EvidenceStep
 from factchecker.steps.verdict_retry import chat_with_verdict_retry
@@ -20,6 +25,9 @@ ADVOCATE_VERDICT_FORMAT = (
 )
 
 
+ADVOCATE_OUTPUT_MODES = ("label_only", "label_and_weights", "weights_only")
+
+
 def _default_advocate_parser(response_content: str) -> Optional[Tuple[str, str]]:
     """Extract verdict and reasoning from response using (( )) format. Returns (label, reasoning) or None."""
     start = response_content.find("((")
@@ -29,6 +37,35 @@ def _default_advocate_parser(response_content: str) -> Optional[Tuple[str, str]]
     label = response_content[start + 2 : end].strip().upper().replace(" ", "_")
     reasoning = (response_content[:start].strip() + " " + response_content[end + 2 :].strip()).strip()
     return label, reasoning
+
+
+def _normalize_parse_result(
+    result: Union[
+        Tuple[str, str],
+        Tuple[Optional[str], str, Optional[dict]],
+        Tuple[Optional[str], str, Optional[dict], Optional[List[str]]],
+    ],
+) -> Tuple[Optional[str], str, Optional[dict], Optional[List[str]]]:
+    """Normalize parser output to (label_or_none, reasoning, weights_or_none, selected_chunk_ids_or_none)."""
+    if result is None or len(result) < 2:
+        return None, "", None, None
+    if len(result) == 2:
+        return result[0], result[1], None, None
+    if len(result) == 3:
+        return result[0], result[1], result[2], None
+    return result[0], result[1], result[2] if len(result) > 2 else None, result[3] if len(result) > 3 else None
+
+
+def _primary_from_label_and_weights(
+    label_or_none: Optional[str],
+    weights_or_none: Optional[dict],
+) -> Optional[str]:
+    """Compute primary verdict: use label if present, else argmax(weights)."""
+    if label_or_none:
+        return label_or_none
+    if weights_or_none and isinstance(weights_or_none, dict) and len(weights_or_none) > 0:
+        return max(weights_or_none, key=weights_or_none.get)
+    return None
 
 
 class AdvocateStep:
@@ -70,9 +107,21 @@ class AdvocateStep:
         self.label_options = self.options.pop('label_options', DEFAULT_LABEL_OPTIONS)
         self.max_retries = self.options.pop('max_retries', 3)
         self.chat_completion_options = self.options.pop('chat_completion_options', {})
-        # Optional custom parser: (response_content: str) -> Optional[Tuple[label, reasoning]]
-        self.verdict_parser: Optional[Callable[[str], Optional[Tuple[str, str]]]] = self.options.pop('verdict_parser', None)
-        
+        # Optional custom parser: may return (label, reasoning) or (label?, reasoning, weights?).
+        self.verdict_parser: Optional[Callable[[str], Optional[Union[Tuple[str, str], Tuple[Optional[str], str, Optional[dict]]]]]] = self.options.pop('verdict_parser', None)
+        # Optional evidence classifier: when set, each retrieved chunk is
+        # classified as supports/refutes/nei before being sent to the LLM.
+        self.evidence_classifier = self.options.pop('evidence_classifier', None)
+        self.verdict_format = self.options.pop('verdict_format', ADVOCATE_VERDICT_FORMAT)
+        # Advocate output mode: label_only (default), label_and_weights, or weights_only.
+        self.advocate_output_mode: str = self.options.pop('advocate_output_mode', 'label_only')
+        if self.advocate_output_mode not in ADVOCATE_OUTPUT_MODES:
+            self.advocate_output_mode = 'label_only'
+        # "full" = advocate sees full chunk text; "relevant_only" = only relevant_phrase or placeholder
+        self.advocate_evidence_display: str = self.options.pop('advocate_evidence_display', 'full')
+        if self.advocate_evidence_display not in ('full', 'relevant_only'):
+            self.advocate_evidence_display = 'full'
+
         # Initialize EvidenceStep
         self.evidence_step = EvidenceStep(
             retriever=retriever,
@@ -94,37 +143,79 @@ class AdvocateStep:
         """
         return self.evidence_step.gather_evidence(claim)
 
-    def evaluate_claim(self, claim: str) -> tuple[str, str]:
+    def evaluate_claim(self, claim: str) -> tuple[str, str, Optional[list], Optional[dict], Optional[list]]:
         """
         Evaluate a claim based on gathered evidence using the language model.
 
-        Args:
-            claim (str): The claim to evaluate.
-
         Returns:
-            A tuple including the label and reasoning.
-
+            (primary_verdict, reasoning, evidence_metadata, optional_weights, selected_chunk_ids).
+            primary_verdict is always a single label (from parser or argmax(weights)).
+            evidence_metadata is a list of dicts when evidence_classifier is set; else None.
+            optional_weights is the advocate weight distribution when mode is label_and_weights or weights_only; else None.
+            selected_chunk_ids is a list of chunk IDs the advocate chose as proof (when parser returns 4-tuple); else None.
         """
-        # Retrieve evidence for the claim
-        evidence_list = self.retrieve_evidence(claim)
+        evidence_metadata = None
 
-        # Define the message containing the payload for the LLM
-        user_prompt = get_default_user_prompt(claim=claim, evidence=evidence_list, label_options=self.label_options)
+        if self.evidence_classifier is not None:
+            evidence_items = self.evidence_step.gather_evidence_with_metadata(claim)
+            if evidence_items:
+                classified = self.evidence_classifier.classify(claim, evidence_items)
+                evidence_metadata = classified
+                chunk_stats = chunk_stats_from_classified(classified)
+                user_prompt = get_classified_evidence_user_prompt(
+                    claim=claim,
+                    classified_evidence=classified,
+                    label_options=self.label_options,
+                    evidence_display_mode=self.advocate_evidence_display,
+                    chunk_stats=chunk_stats,
+                )
+            else:
+                user_prompt = get_classified_evidence_user_prompt(
+                    claim=claim,
+                    classified_evidence=[],
+                    label_options=self.label_options,
+                    evidence_display_mode=self.advocate_evidence_display,
+                    chunk_stats=chunk_stats_from_classified([]),
+                )
+        else:
+            evidence_list = self.retrieve_evidence(claim)
+            user_prompt = get_default_user_prompt(
+                claim=claim, evidence=evidence_list, label_options=self.label_options
+            )
 
         messages = [
             ChatMessage(role="system", content=self.system_prompt),
-            ChatMessage(role="user", content=user_prompt)
+            ChatMessage(role="user", content=user_prompt),
         ]
+        if evidence_metadata:
+            logger.info(
+                "Advocate evidence for claim (first 120 chars): %s",
+                (claim[:120] + "..." if len(claim) > 120 else claim),
+            )
+            for j, chunk in enumerate(evidence_metadata):
+                text_preview = (chunk.get("text") or "")[:200]
+                if len(chunk.get("text") or "") > 200:
+                    text_preview += "..."
+                logger.info(
+                    "  Chunk %s [%s] (relevant_phrase: %s): %s",
+                    chunk.get("chunk_id", j),
+                    chunk.get("stance", "?"),
+                    (chunk.get("relevant_phrase") or "")[:80] or "(none)",
+                    text_preview,
+                )
         parse_fn = self.verdict_parser if self.verdict_parser is not None else _default_advocate_parser
         result = chat_with_verdict_retry(
             messages,
             self.llm,
             parse_fn,
-            ADVOCATE_VERDICT_FORMAT,
+            self.verdict_format,
             self.max_retries,
             self.chat_completion_options,
             logger,
         )
         if result is not None:
-            return result[0], result[1]
-        return "ERROR_PARSING_RESPONSE", "No reasoning available"
+            label_or_none, reasoning, weights_or_none, selected_chunk_ids = _normalize_parse_result(result)
+            primary = _primary_from_label_and_weights(label_or_none, weights_or_none)
+            if primary is not None:
+                return primary, reasoning, evidence_metadata, weights_or_none, selected_chunk_ids
+        return "ERROR_PARSING_RESPONSE", "No reasoning available", evidence_metadata, None, None

--- a/factchecker/steps/evidence.py
+++ b/factchecker/steps/evidence.py
@@ -78,7 +78,38 @@ class EvidenceStep:
         logging.info(f"Extracted text from {len(evidence_texts)} evidence nodes")
 
         return evidence_texts
-    
+
+    def gather_evidence_with_metadata(self, claim: str) -> list[dict]:
+        """
+        Gather evidence and return list of dicts with chunk_id, text, and score
+        for tracking and for use with evidence classifier (relevant phrase, etc.).
+        """
+        query = self.build_query(claim)
+        evidence = self.retriever.retrieve(query)
+        if not isinstance(evidence, list) or not evidence:
+            return []
+        if not isinstance(evidence[0], NodeWithScore):
+            logging.error("Evidence items are not NodeWithScore; returning empty list.")
+            return []
+        filtered_evidence = self.classify_evidence(evidence)
+        if not filtered_evidence:
+            return []
+        result = []
+        for i, item in enumerate(filtered_evidence):
+            node = item.node
+            chunk_id = getattr(node, "node_id", None) or getattr(node, "id", None)
+            if chunk_id is None:
+                chunk_id = f"chunk_{i}"
+            if hasattr(chunk_id, "hex"):  # UUID
+                chunk_id = str(chunk_id)
+            result.append({
+                "chunk_id": chunk_id,
+                "text": node.text,
+                "score": float(item.score) if item.score is not None else 0.0,
+            })
+        logging.info(f"Retrieved {len(result)} evidence nodes with metadata for claim: {claim}")
+        return result
+
     def extract_text_from_evidence(self, evidence: list[NodeWithScore]) -> list[str]:
         """
         Extract text from evidence nodes.

--- a/factchecker/steps/evidence_classifier.py
+++ b/factchecker/steps/evidence_classifier.py
@@ -1,0 +1,262 @@
+"""
+EvidenceClassifierStep — classifies each retrieved chunk as
+supports / refutes / not_enough_information relative to a claim.
+
+One LLM call per invocation (all chunks classified in a single request).
+Can optionally request and parse a "relevant_phrase" per chunk.
+
+Prompts can be overridden per experiment via options:
+  - system_prompt: str
+  - user_prompt_fn: callable (claim, evidence_items, include_relevant_phrase) -> str
+"""
+import json
+import logging
+from typing import Callable, List, Optional, Union
+
+from llama_index.core.llms import ChatMessage
+
+from factchecker.core.llm import load_llm
+from factchecker.prompts.evidence_classifier_prompts import (
+    EVIDENCE_CLASSIFIER_SYSTEM_PROMPT,
+    EVIDENCE_STANCES,
+    get_evidence_classifier_user_prompt,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _has_required_phrases(parsed: dict, n_expected: int) -> bool:
+    """True if every chunk with stance supports/refutes has a non-empty relevant_phrase."""
+    for i in range(n_expected):
+        entry = parsed.get(i, {})
+        stance = entry.get("stance", "")
+        if stance in ("supports", "refutes"):
+            phrase = (entry.get("relevant_phrase") or "").strip()
+            if not phrase:
+                return False
+    return True
+
+
+def _has_required_reasons(parsed: dict, n_expected: int) -> bool:
+    """True if every chunk with stance supports/refutes has a non-empty reason (when reason is used)."""
+    for i in range(n_expected):
+        entry = parsed.get(i, {})
+        stance = entry.get("stance", "")
+        if stance in ("supports", "refutes"):
+            reason = (entry.get("reason") or "").strip()
+            if not reason:
+                return False
+    return True
+
+
+def _normalize_evidence_items(
+    evidence_items: Union[List[str], List[dict]],
+) -> List[dict]:
+    """Normalize to list of dicts with chunk_id and text."""
+    out = []
+    for i, item in enumerate(evidence_items):
+        if isinstance(item, str):
+            out.append({"chunk_id": str(i), "text": item})
+        else:
+            out.append({
+                "chunk_id": item.get("chunk_id", str(i)),
+                "text": item.get("text", ""),
+            })
+    return out
+
+
+class EvidenceClassifierStep:
+    """Classify a list of evidence texts against a claim (supports / refutes / nei)."""
+
+    def __init__(self, llm=None, options: Optional[dict] = None):
+        opts = dict(options) if options else {}
+        self.llm = llm if llm is not None else load_llm()
+        self.max_retries: int = opts.pop("max_retries", 3)
+        self.system_prompt: str = opts.pop("system_prompt", EVIDENCE_CLASSIFIER_SYSTEM_PROMPT)
+        self.include_relevant_phrase: bool = opts.pop("include_relevant_phrase", True)
+        self.include_reason: bool = opts.pop("include_reason", False)
+        self.allowed_reasons: tuple = opts.pop("allowed_reasons", ())
+        self.user_prompt_fn: Optional[Callable] = opts.pop("user_prompt_fn", None)
+        if self.user_prompt_fn is None:
+            self.user_prompt_fn = get_evidence_classifier_user_prompt
+
+    # ------------------------------------------------------------------
+    def classify(
+        self,
+        claim: str,
+        evidence_items: Union[List[str], List[dict]],
+    ) -> List[dict]:
+        """
+        Classify each evidence piece relative to *claim*.
+
+        evidence_items: List of str (plain text) or List of dict with "text" and optional "chunk_id".
+
+        Returns:
+            List of dicts with "chunk_id", "text", "stance", and optionally "relevant_phrase".
+
+        Raises:
+            ValueError: If the LLM response cannot be parsed after all retries (no default to NEI).
+        """
+        items = _normalize_evidence_items(evidence_items)
+        if not items:
+            return []
+
+        evidence_texts = [e["text"] for e in items]
+        chunk_ids = [e["chunk_id"] for e in items]
+        n_expected = len(items)
+        user_prompt = self._build_user_prompt(claim, evidence_texts, chunk_ids)
+        messages = [
+            ChatMessage(role="system", content=self.system_prompt),
+            ChatMessage(role="user", content=user_prompt),
+        ]
+
+        last_raw = ""
+        for attempt in range(1, self.max_retries + 1):
+            raw = self._call_llm(messages)
+            last_raw = raw
+            parsed = self._parse_response(
+                raw,
+                n_expected,
+                self.include_relevant_phrase,
+                self.include_reason,
+                self.allowed_reasons,
+            )
+            if parsed and all(i in parsed for i in range(n_expected)):
+                missing_phrase = (
+                    self.include_relevant_phrase
+                    and not _has_required_phrases(parsed, n_expected)
+                )
+                missing_reason = (
+                    self.include_reason
+                    and not _has_required_reasons(parsed, n_expected)
+                )
+                if (missing_phrase or missing_reason) and attempt < 3:
+                    if missing_phrase:
+                        logger.warning(
+                            "EvidenceClassifier: supports/refutes missing required relevant_phrase; retrying (attempt %s).",
+                            attempt,
+                        )
+                    if missing_reason:
+                        logger.warning(
+                            "EvidenceClassifier: supports/refutes missing required reason; retrying (attempt %s).",
+                            attempt,
+                        )
+                else:
+                    if missing_phrase and attempt >= 3:
+                        logger.info(
+                            "EvidenceClassifier: accepting response after 2 retries; some supports/refutes have empty relevant_phrase."
+                        )
+                    if missing_reason and attempt >= 3:
+                        logger.info(
+                            "EvidenceClassifier: accepting response after 2 retries; some supports/refutes have empty reason."
+                        )
+                    return [
+                        {
+                            "chunk_id": items[i]["chunk_id"],
+                            "text": items[i]["text"],
+                            "stance": parsed.get(i, {}).get("stance", "not_enough_information"),
+                            **(
+                                {"relevant_phrase": parsed.get(i, {}).get("relevant_phrase", "")}
+                                if self.include_relevant_phrase
+                                else {}
+                            ),
+                            **(
+                                {"reason": parsed.get(i, {}).get("reason", "")}
+                                if self.include_reason
+                                else {}
+                            ),
+                        }
+                        for i in range(n_expected)
+                    ]
+            else:
+                logger.warning(
+                    "EvidenceClassifier: parse attempt %s/%s failed (got %s entries, expected %s). Raw response (first 600 chars): %s",
+                    attempt,
+                    self.max_retries,
+                    len(parsed) if parsed else 0,
+                    n_expected,
+                    (raw[:600] + "..." if len(raw) > 600 else raw) or "(empty)",
+                )
+
+        logger.error(
+            "EvidenceClassifier: all %s retries exhausted. Last raw response (first 800 chars): %s",
+            self.max_retries,
+            (last_raw[:800] + "..." if len(last_raw) > 800 else last_raw) or "(empty)",
+        )
+        raise ValueError(
+            "Evidence classifier failed to produce a valid parse after %s retries; cannot default to NEI."
+            % self.max_retries
+        )
+
+    def _build_user_prompt(
+        self, claim: str, evidence_texts: List[str], chunk_ids: List[str]
+    ) -> str:
+        if self.user_prompt_fn is None:
+            return get_evidence_classifier_user_prompt(
+                claim, evidence_texts, self.include_relevant_phrase, chunk_ids
+            )
+        sig = getattr(self.user_prompt_fn, "__code__", None)
+        varnames = (sig.co_varnames if sig else [])[: (sig.co_argcount if sig else 0)]
+        if "include_reason" in varnames:
+            return self.user_prompt_fn(
+                claim,
+                evidence_texts,
+                self.include_relevant_phrase,
+                chunk_ids,
+                self.include_reason,
+            )
+        if "include_relevant_phrase" in varnames:
+            return self.user_prompt_fn(
+                claim, evidence_texts, self.include_relevant_phrase, chunk_ids
+            )
+        return self.user_prompt_fn(claim, evidence_texts)
+
+    # ------------------------------------------------------------------
+    def _call_llm(self, messages: list) -> str:
+        response = self.llm.chat(messages)
+        return response.message.content
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _parse_response(
+        raw: str,
+        n_expected: int,
+        include_relevant_phrase: bool = False,
+        include_reason: bool = False,
+        allowed_reasons: tuple = (),
+    ) -> dict:
+        """
+        Parse LLM JSON array into {id: {stance, relevant_phrase?, reason?}}.
+        reason is normalized to one of allowed_reasons or empty string.
+        """
+        text = raw.strip()
+        start = text.find("[")
+        end = text.rfind("]")
+        if start == -1 or end == -1:
+            logger.warning("EvidenceClassifier: no JSON array found in response")
+            return {}
+        try:
+            arr = json.loads(text[start : end + 1])
+        except json.JSONDecodeError as e:
+            logger.warning("EvidenceClassifier: JSON parse failed: %s", e)
+            return {}
+
+        allowed_set = frozenset(str(r).strip().lower().replace(" ", "_") for r in allowed_reasons)
+        mapping: dict[int, dict] = {}
+        for item in arr:
+            if not isinstance(item, dict):
+                continue
+            idx = item.get("id")
+            stance = str(item.get("stance", "")).strip().lower().replace(" ", "_")
+            if stance not in EVIDENCE_STANCES:
+                stance = "not_enough_information"
+            if isinstance(idx, int) and 0 <= idx < n_expected:
+                entry = {"stance": stance}
+                if include_relevant_phrase:
+                    rp = item.get("relevant_phrase", "")
+                    entry["relevant_phrase"] = str(rp).strip() if rp else ""
+                if include_reason:
+                    raw_reason = str(item.get("reason", "")).strip().lower().replace(" ", "_")
+                    entry["reason"] = raw_reason if raw_reason in allowed_set else ""
+                mapping[idx] = entry
+        return mapping

--- a/factchecker/steps/mediator.py
+++ b/factchecker/steps/mediator.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Callable, Optional
 
@@ -48,28 +49,47 @@ class MediatorStep:
         self.system_prompt = self.options.pop('system_prompt', '')
         self.max_retries = self.options.pop('max_retries', 3)
         self.verdict_parser: Optional[Callable[[str], Optional[str]]] = self.options.pop('verdict_parser', None)
+        self.verdict_format_instruction: Optional[str] = self.options.pop('verdict_format_instruction', None)
+        self.user_message_suffix: Optional[str] = self.options.pop('user_message_suffix', None)
         self.additional_options = {key: self.options.pop(key) for key in list(self.options.keys())}
 
-    def synthesize_verdicts(self, verdicts_and_reasonings, claim):
+    def synthesize_verdicts(
+        self,
+        verdicts_and_reasonings,
+        claim: str,
+        evidence_summary: Optional[str] = None,
+    ):
         """
         Synthesize multiple verdicts and their reasoning into a final consensus verdict.
 
         Args:
-            verdicts_and_reasonings (list): List of (verdict, reasoning) tuples from advocates
+            verdicts_and_reasonings (list): List of (verdict, reasoning) or (verdict, reasoning, weights_dict) per advocate
             claim (str): The claim being evaluated
+            evidence_summary (str, optional): Most relevant supporting/refuting evidence to show the mediator
 
         Returns:
-            str: The final consensus verdict (CORRECT, INCORRECT, NOT_ENOUGH_INFORMATION, or ERROR_PARSING_RESPONSE)
+            str: The final consensus verdict (or weighted JSON string when using custom verdict_parser)
         """
-        # Format the verdicts and reasonings with <> tags
-        formatted_verdicts_and_reasonings = "\n".join(
-            [f"<verdict>{verdict}</verdict><reasoning>{reasoning}</reasoning>" for verdict, reasoning in verdicts_and_reasonings]
-        )
+        lines = []
+        for item in verdicts_and_reasonings:
+            verdict = item[0]
+            reasoning = item[1] if len(item) > 1 else ""
+            line = f"<verdict>{verdict}</verdict><reasoning>{reasoning}</reasoning>"
+            if len(item) > 2 and item[2] is not None:
+                weights = item[2]
+                if isinstance(weights, dict):
+                    line += f"<weight_distribution>{json.dumps(weights)}</weight_distribution>"
+            lines.append(line)
+        formatted_verdicts_and_reasonings = "\n".join(lines)
         
         user_content = (
             f"Here are the verdicts and reasonings of the different advocates:\n{formatted_verdicts_and_reasonings}\n"
             f"Please provide the final verdict as ((correct)), ((incorrect)), or ((not_enough_information)) for the claim: {claim}"
         )
+        if evidence_summary:
+            user_content += f"\n\nMost relevant evidence from the advocates:\n{evidence_summary}"
+        if self.user_message_suffix:
+            user_content += self.user_message_suffix
         messages = [
             ChatMessage(role="system", content=self.system_prompt),
             ChatMessage(role="user", content=user_content)
@@ -77,11 +97,12 @@ class MediatorStep:
 
         valid_options = {key: value for key, value in self.additional_options.items() if key in ["response_format", "temperature", "max_tokens", "top_p", "frequency_penalty", "presence_penalty"]}
         parse_fn = self.verdict_parser if self.verdict_parser is not None else _default_mediator_parser
+        format_instruction = self.verdict_format_instruction if self.verdict_format_instruction is not None else MEDIATOR_VERDICT_FORMAT
         result = chat_with_verdict_retry(
             messages,
             self.llm,
             parse_fn,
-            MEDIATOR_VERDICT_FORMAT,
+            format_instruction,
             self.max_retries,
             valid_options,
             logger,

--- a/factchecker/strategies/advocate_mediator.py
+++ b/factchecker/strategies/advocate_mediator.py
@@ -1,7 +1,170 @@
+import json
+from typing import List, Optional, Sequence
+
 from factchecker.steps.advocate import AdvocateStep
 from factchecker.steps.mediator import MediatorStep
 from factchecker.indexing.llama_vector_store_indexer import LlamaVectorStoreIndexer
 from factchecker.retrieval.llama_base_retriever import LlamaBaseRetriever
+
+
+def _build_evidence_summary_for_mediator(
+    evidence_metadata_per_advocate: List[Optional[List[dict]]],
+    use_relevant_only: bool = False,
+) -> str:
+    """
+    Build a short summary of supporting and refuting evidence from per-advocate chunk metadata
+    for the mediator prompt. Each advocate's chunks are lists of dicts with stance, text, relevant_phrase.
+    If use_relevant_only is True, only the relevant_phrase is shown (or "[no relevant part]" when missing),
+    and a statistics line is appended so NIN and chunks without a phrase are accounted for.
+    """
+    supporting: List[str] = []
+    refuting: List[str] = []
+    n_with_phrase = 0
+    n_without_phrase = 0
+    for meta_list in evidence_metadata_per_advocate or []:
+        if not meta_list:
+            continue
+        for chunk in meta_list:
+            if not isinstance(chunk, dict):
+                continue
+            stance = (chunk.get("stance") or "").strip().lower()
+            phrase = (chunk.get("relevant_phrase") or "").strip()
+            text = (chunk.get("text") or "").strip()
+            if use_relevant_only:
+                snippet = phrase if phrase else "[no relevant part]"
+                if phrase:
+                    n_with_phrase += 1
+                else:
+                    n_without_phrase += 1
+            else:
+                snippet = phrase if phrase else (text[:200] + "..." if len(text) > 200 else text)
+            if not snippet and not use_relevant_only:
+                continue
+            if stance == "supports":
+                supporting.append(snippet)
+            elif stance == "refutes":
+                refuting.append(snippet)
+    lines = []
+    if supporting:
+        lines.append("Supporting:")
+        for s in supporting[:10]:  # cap to avoid huge prompts
+            lines.append(f"- {s}")
+    if refuting:
+        lines.append("Refuting:")
+        for r in refuting[:10]:
+            lines.append(f"- {r}")
+    if use_relevant_only and (n_with_phrase > 0 or n_without_phrase > 0):
+        lines.append(f"Statistics: {n_with_phrase} chunk(s) with relevant phrase, {n_without_phrase} without.")
+    return "\n".join(lines) if lines else ""
+
+
+def _verdict_wants_supports(verdict: str) -> Optional[bool]:
+    """
+    True = advocate says claim is right → show chunks that support the claim ("supports").
+    False = advocate says claim is wrong → show chunks that refute the claim ("refutes").
+    None = neutral (e.g. not_enough_information) → no proof chunks.
+    """
+    v = (verdict or "").strip().lower().replace(" ", "_")
+    if v == "not_enough_information" or v == "not_enough_info":
+        return None
+    pro = (
+        "accurate", "correct", "mostly_accurate", "mostly_correct",
+        "correct_but", "partially_correct", "lacks_context", "imprecise", "unsupported",
+    )
+    con = ("inaccurate", "incorrect", "flawed_reasoning", "misleading")
+    if v in pro:
+        return True
+    if v in con:
+        return False
+    return None
+
+
+def _build_advocate_proof_for_mediator(
+    evidence_metadata_per_advocate: List[Optional[List[dict]]],
+    verdicts: List[str],
+    max_chunks: int = 3,
+    selected_chunk_ids_per_advocate: Optional[Sequence[Optional[List[str]]]] = None,
+    use_relevant_only: bool = False,
+) -> str:
+    """
+    Build a short summary of up to max_chunks chunks that the advocate uses to prove its verdict.
+    - When selected_chunk_ids_per_advocate is provided and non-empty for an advocate, use only
+      those chunk IDs (the advocate explicitly picked them).
+    - Otherwise fall back to verdict-based selection: pro-claim → "supports" chunks,
+      anti-claim → "refutes" chunks, neutral → none.
+    If use_relevant_only is True, only the relevant_phrase is shown (or "[no relevant part]");
+    a statistics line is appended for chunks with/without relevant phrase.
+    """
+    chosen: List[str] = []
+    n_with_phrase = 0
+    n_without_phrase = 0
+
+    def _snippet(chunk: dict) -> tuple:
+        phrase = (chunk.get("relevant_phrase") or "").strip()
+        text = (chunk.get("text") or "").strip()
+        if use_relevant_only:
+            s = phrase if phrase else "[no relevant part]"
+            return s, bool(phrase)
+        s = phrase if phrase else (text[:200] + "..." if len(text) > 200 else text)
+        return s, True
+
+    for adv_idx, meta_list in enumerate(evidence_metadata_per_advocate or []):
+        if len(chosen) >= max_chunks or not meta_list:
+            continue
+        selected_ids: Optional[List[str]] = None
+        if selected_chunk_ids_per_advocate and adv_idx < len(selected_chunk_ids_per_advocate):
+            sel = selected_chunk_ids_per_advocate[adv_idx]
+            if sel:
+                selected_ids = [str(s).strip() for s in sel if s]
+        if selected_ids:
+            id_set = set(selected_ids)
+            for chunk in meta_list:
+                if len(chosen) >= max_chunks:
+                    break
+                if not isinstance(chunk, dict):
+                    continue
+                cid = chunk.get("chunk_id")
+                if cid is None or str(cid).strip() not in id_set:
+                    continue
+                snippet, has_phrase = _snippet(chunk)
+                if snippet:
+                    chosen.append(snippet)
+                    if use_relevant_only:
+                        if has_phrase:
+                            n_with_phrase += 1
+                        else:
+                            n_without_phrase += 1
+            continue
+        verdict = verdicts[adv_idx] if adv_idx < len(verdicts) else ""
+        use_supports = _verdict_wants_supports(verdict)
+        if use_supports is None:
+            continue
+        want_stance = "supports" if use_supports else "refutes"
+        for chunk in meta_list:
+            if len(chosen) >= max_chunks:
+                break
+            if not isinstance(chunk, dict):
+                continue
+            stance = (chunk.get("stance") or "").strip().lower()
+            if stance != want_stance:
+                continue
+            snippet, has_phrase = _snippet(chunk)
+            if snippet:
+                chosen.append(snippet)
+                if use_relevant_only:
+                    if has_phrase:
+                        n_with_phrase += 1
+                    else:
+                        n_without_phrase += 1
+    if not chosen:
+        return ""
+    lines = ["Chunks the advocate selected to support its verdict:"]
+    for s in chosen:
+        lines.append(f"- {s}")
+    if use_relevant_only and (n_with_phrase > 0 or n_without_phrase > 0):
+        lines.append(f"Statistics: {n_with_phrase} with relevant phrase, {n_without_phrase} without.")
+    return "\n".join(lines)
+
 
 class AdvocateMediatorStrategy:
     """
@@ -56,6 +219,10 @@ class AdvocateMediatorStrategy:
             self.advocate_steps.append(advocate_step)
             
         self.mediator_step = MediatorStep(options=mediator_options)
+        self.mediator_mode = mediator_options.get("mediator_mode", "llm")
+        self._formula_fn = mediator_options.get("formula_fn")
+        self._mediator_proof_max_chunks = mediator_options.get("mediator_proof_max_chunks", 3)
+        self._mediator_evidence_relevant_only = mediator_options.get("mediator_evidence_relevant_only", False)
 
     def evaluate_claim(self, claim):
         """
@@ -65,19 +232,48 @@ class AdvocateMediatorStrategy:
             claim (str): The claim to evaluate
 
         Returns:
-            tuple: A tuple containing:
-                - final_verdict (str): The consensus verdict
-                - verdicts (list): List of individual advocate verdicts
-                - reasonings (list): List of advocate reasonings
+            tuple: (final_verdict, verdicts, reasonings, evidence_metadata_per_advocate, advocate_weights_per_advocate).
+            evidence_metadata_per_advocate is a list of list-of-dicts (one per advocate).
+            advocate_weights_per_advocate is a list of optional dicts (one per advocate); None when advocate did not output weights.
         """
-        # Each advocate evaluates the claim based on their own evidence
-        verdicts_and_reasonings = [advocate.evaluate_claim(claim) for advocate in self.advocate_steps]
+        results = [advocate.evaluate_claim(claim) for advocate in self.advocate_steps]
+        verdicts = [r[0] for r in results]
+        reasonings = [r[1] for r in results]
+        evidence_metadata_per_advocate = [r[2] if len(r) > 2 else None for r in results]
+        advocate_weights_per_advocate = [r[3] if len(r) > 3 else None for r in results]
+        selected_chunk_ids_per_advocate = [r[4] if len(r) > 4 else None for r in results]
 
-        # Separate verdicts and reasonings
-        verdicts = [verdict for verdict, reasoning in verdicts_and_reasonings]
-        reasonings = [reasoning for verdict, reasoning in verdicts_and_reasonings]
+        # Each item is (verdict, reasoning) or (verdict, reasoning, weights_dict) for mediator
+        verdicts_and_reasonings = []
+        for v, r, w in zip(verdicts, reasonings, advocate_weights_per_advocate):
+            if w is not None:
+                verdicts_and_reasonings.append((v, r, w))
+            else:
+                verdicts_and_reasonings.append((v, r))
 
-        # The mediator synthesizes the verdicts
-        final_verdict = self.mediator_step.synthesize_verdicts(verdicts_and_reasonings, claim)
+        if self.mediator_mode == "formula" and self._formula_fn is not None:
+            _primary, combined_weights = self._formula_fn(advocate_weights_per_advocate)
+            final_verdict = json.dumps(combined_weights)
+        elif self.mediator_mode == "llm_with_evidence":
+            evidence_summary = _build_evidence_summary_for_mediator(
+                evidence_metadata_per_advocate,
+                use_relevant_only=getattr(self, "_mediator_evidence_relevant_only", False),
+            )
+            final_verdict = self.mediator_step.synthesize_verdicts(
+                verdicts_and_reasonings, claim, evidence_summary=evidence_summary
+            )
+        elif self.mediator_mode == "llm_with_advocate_proof":
+            proof_summary = _build_advocate_proof_for_mediator(
+                evidence_metadata_per_advocate,
+                verdicts,
+                max_chunks=getattr(self, "_mediator_proof_max_chunks", 3),
+                selected_chunk_ids_per_advocate=selected_chunk_ids_per_advocate,
+                use_relevant_only=getattr(self, "_mediator_evidence_relevant_only", False),
+            )
+            final_verdict = self.mediator_step.synthesize_verdicts(
+                verdicts_and_reasonings, claim, evidence_summary=proof_summary
+            )
+        else:
+            final_verdict = self.mediator_step.synthesize_verdicts(verdicts_and_reasonings, claim)
 
-        return final_verdict, verdicts, reasonings
+        return final_verdict, verdicts, reasonings, evidence_metadata_per_advocate, advocate_weights_per_advocate

--- a/factchecker/tools/analyze_spectrum_results.py
+++ b/factchecker/tools/analyze_spectrum_results.py
@@ -1,0 +1,72 @@
+"""
+CLI to analyze existing Spectrum results CSV (weighted metrics + classification report).
+
+Business logic in factchecker.utils.spectrum_analysis (same layer as metrics, experiment_utils).
+
+Usage:
+  python -m factchecker.tools.analyze_spectrum_results
+  python -m factchecker.tools.analyze_spectrum_results --results path/to/spectrum_claims_results_*.csv
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from factchecker.utils.spectrum_analysis import (
+    find_latest_spectrum_results_csv,
+    run_spectrum_analysis,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Analyze existing Spectrum results CSV (weighted metrics, optional classification report)."
+    )
+    parser.add_argument(
+        "--results",
+        default=None,
+        help="Path to spectrum_claims_results_*.csv. If omitted, uses most recent in experiments/results/.",
+    )
+    args = parser.parse_args()
+
+    if args.results:
+        path = Path(args.results)
+        if not path.exists():
+            print(f"Error: File not found: {path}", file=sys.stderr)
+            sys.exit(1)
+        csv_path = str(path)
+    else:
+        latest = find_latest_spectrum_results_csv()
+        if latest is None:
+            print(
+                "Error: No spectrum_claims_results_*.csv found. Pass --results path/to/file.csv",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        csv_path = str(latest)
+
+    result = run_spectrum_analysis(csv_path)
+
+    if result.error:
+        print(f"Error: {result.error}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Loaded {result.n_rows} rows from {csv_path}\n")
+
+    if result.classification_report:
+        print("Classification Metrics (primary verdict vs true):")
+        print(result.classification_report)
+
+    if result.normalized_reports:
+        print("\n--- Normalized (clustered) metrics ---")
+        for (level, role) in [(2, "advocate"), (2, "mediator"), (5, "advocate"), (5, "mediator")]:
+            key = (level, role)
+            if key in result.normalized_reports:
+                print(result.normalized_reports[key])
+
+    if result.weighted_metrics_text:
+        print(result.weighted_metrics_text)
+
+
+if __name__ == "__main__":
+    main()

--- a/factchecker/utils/climatefeedback_utils.py
+++ b/factchecker/utils/climatefeedback_utils.py
@@ -170,7 +170,7 @@ def evaluate_climatefeedback_claim(
         Exception: If evaluation fails
     """
     try:
-        final_verdict, verdicts, reasonings = strategy.evaluate_claim(claim)
+        final_verdict, verdicts, reasonings, _, _ = strategy.evaluate_claim(claim)
         collectors = collect_evaluation_results(
             collectors,
             (true_label, final_verdict, verdicts, reasonings),

--- a/factchecker/utils/experiment_utils.py
+++ b/factchecker/utils/experiment_utils.py
@@ -113,6 +113,7 @@ def initialize_results_collectors(num_advocates: int) -> ResultsDict:
         'advocate_evidences': [[] for _ in range(num_advocates)],
         'advocate_verdicts': [[] for _ in range(num_advocates)],
         'advocate_reasonings': [[] for _ in range(num_advocates)],
+        'advocate_weighted_verdicts': [[] for _ in range(num_advocates)],
         'claim_indices': [],
     }
 

--- a/factchecker/utils/metrics.py
+++ b/factchecker/utils/metrics.py
@@ -36,4 +36,6 @@ def calculate_classification_metrics(
         true_labels = [label.lower() for label in true_labels]
         predicted_results = [result.lower() for result in predicted_results]
     
-    return classification_report(true_labels, predicted_results) 
+    return classification_report(
+        true_labels, predicted_results, zero_division=0
+    ) 

--- a/factchecker/utils/spectrum_analysis.py
+++ b/factchecker/utils/spectrum_analysis.py
@@ -1,0 +1,194 @@
+"""
+Analyze Spectrum experiment results (CSV).
+
+Loads a spectrum_claims_results_*.csv, resolves true labels to the Science Feedback
+verdict scale, and computes classification metrics (primary verdict) and weighted
+distribution metrics (log loss, top-k accuracy). No LLM or model calls.
+
+Used by factchecker.tools.analyze_spectrum_results and the Spectrum experiment script.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+import pandas as pd
+
+from factchecker.utils.climatefeedback_utils import map_verdict
+from factchecker.utils.metrics import calculate_classification_metrics
+
+from factchecker.experiments.advocate_mediator_climatefeedback_spectrum.weighted_metrics import (
+    format_weighted_metrics,
+    log_loss,
+    top_k_accuracy,
+)
+
+
+def _cluster_verdict_for_metrics(label: str, level: int) -> str:
+    """Map a single verdict (our format, e.g. mostly_accurate) to clustered label at given level (2 or 5)."""
+    if not label or not isinstance(label, str):
+        return "unknown"
+    normalized_input = label.strip().lower().replace("_", " ")
+    return map_verdict(normalized_input, level=level)
+
+
+@dataclass
+class SpectrumAnalysisResult:
+    """Result of running spectrum analysis on a results CSV."""
+
+    n_rows: int
+    classification_report: Optional[str] = None
+    weighted_metrics_text: Optional[str] = None
+    log_loss_value: Optional[float] = None
+    top_2_accuracy: Optional[float] = None
+    top_3_accuracy: Optional[float] = None
+    error: Optional[str] = None
+    # Normalized (clustered) metrics: key (level, role) -> report string
+    normalized_reports: Optional[dict] = None
+
+
+def _normalize_predicted(p: str) -> str:
+    if not p or not isinstance(p, str):
+        return "unknown"
+    s = p.strip().lower().replace(" ", "_")
+    if s == "not_enough_info":
+        return "not_enough_information"
+    return s
+
+
+def _resolve_true_labels(df: pd.DataFrame) -> Optional[List[str]]:
+    """
+    Resolve true labels to Science Feedback verdict scale (level-7).
+    Prefers 'True Label (SF verdict)', then 'Mapped True Label', then maps 'True Label' with level=7.
+    """
+    if "True Label (SF verdict)" in df.columns:
+        s = df["True Label (SF verdict)"].astype(str).str.strip().str.lower().str.replace(" ", "_")
+        return s.tolist()
+    if "Mapped True Label" in df.columns:
+        s = df["Mapped True Label"].astype(str).str.strip().str.lower().str.replace(" ", "_")
+        return s.tolist()
+    if "True Label" in df.columns:
+        return [map_verdict(str(x), level=7) for x in df["True Label"]]
+    return None
+
+
+def run_spectrum_analysis(csv_path: str) -> SpectrumAnalysisResult:
+    """
+    Load a Spectrum results CSV and compute classification + weighted distribution metrics.
+
+    Args:
+        csv_path: Path to spectrum_claims_results_*.csv (must have 'Weighted verdict'
+                  and one of 'True Label (SF verdict)', 'Mapped True Label', or 'True Label').
+
+    Returns:
+        SpectrumAnalysisResult with n_rows, classification_report, weighted_metrics_text,
+        log_loss_value, top_2_accuracy, top_3_accuracy, or error if invalid.
+    """
+    try:
+        df = pd.read_csv(csv_path)
+    except Exception as e:
+        return SpectrumAnalysisResult(n_rows=0, error=f"Failed to load CSV: {e}")
+
+    if "Weighted verdict" not in df.columns:
+        return SpectrumAnalysisResult(
+            n_rows=len(df),
+            error=f"CSV must have 'Weighted verdict' column. Found: {list(df.columns)}",
+        )
+
+    true_list = _resolve_true_labels(df)
+    if true_list is None:
+        return SpectrumAnalysisResult(
+            n_rows=len(df),
+            error="CSV must have one of 'True Label (SF verdict)', 'Mapped True Label', or 'True Label'.",
+        )
+
+    weighted_verdicts = df["Weighted verdict"].astype(str).tolist()
+    true_list = [t if t and t != "nan" else "unknown" for t in true_list]
+
+    # Classification metrics (primary verdict vs true)
+    classification_report: Optional[str] = None
+    pred_list: Optional[List[str]] = None
+    advocate_list: Optional[List[str]] = None
+    if "Predicted Verdict" in df.columns:
+        pred_list = [_normalize_predicted(str(p)) for p in df["Predicted Verdict"]]
+        try:
+            classification_report = calculate_classification_metrics(
+                true_list, pred_list, verdict_mapper=None
+            )
+        except Exception:
+            pass
+    if "Advocate Primary Verdict" in df.columns:
+        advocate_list = [_normalize_predicted(str(p)) for p in df["Advocate Primary Verdict"]]
+
+    # Normalized (clustered) metrics: level 2 and 5 for advocate and mediator
+    normalized_reports: Optional[dict] = None
+    if true_list and (pred_list is not None or advocate_list is not None):
+        normalized_reports = {}
+        for level in (2, 5):
+            true_clustered = [_cluster_verdict_for_metrics(t, level) for t in true_list]
+            level_name = "correct/incorrect" if level == 2 else "level-5"
+            if advocate_list is not None and len(advocate_list) == len(true_list):
+                adv_clustered = [_cluster_verdict_for_metrics(a, level) for a in advocate_list]
+                try:
+                    normalized_reports[(level, "advocate")] = (
+                        f"--- Advocate primary vs true (normalized, level={level}: {level_name}) ---\n"
+                        + calculate_classification_metrics(
+                            true_clustered, adv_clustered, verdict_mapper=None
+                        )
+                    )
+                except Exception:
+                    pass
+            if pred_list is not None and len(pred_list) == len(true_list):
+                med_clustered = [_cluster_verdict_for_metrics(p, level) for p in pred_list]
+                try:
+                    normalized_reports[(level, "mediator")] = (
+                        f"--- Mediator predicted vs true (normalized, level={level}: {level_name}) ---\n"
+                        + calculate_classification_metrics(
+                            true_clustered, med_clustered, verdict_mapper=None
+                        )
+                    )
+                except Exception:
+                    pass
+
+    # Weighted distribution metrics
+    weighted_metrics_text = format_weighted_metrics(true_list, weighted_verdicts)
+    log_loss_value = log_loss(true_list, weighted_verdicts)
+    top_2 = top_k_accuracy(true_list, weighted_verdicts, 2)
+    top_3 = top_k_accuracy(true_list, weighted_verdicts, 3)
+
+    return SpectrumAnalysisResult(
+        n_rows=len(df),
+        classification_report=classification_report,
+        weighted_metrics_text=weighted_metrics_text,
+        log_loss_value=log_loss_value,
+        top_2_accuracy=top_2,
+        top_3_accuracy=top_3,
+        normalized_reports=normalized_reports or None,
+    )
+
+
+def find_latest_spectrum_results_csv(
+    search_dirs: Optional[List[Path]] = None,
+) -> Optional[Path]:
+    """
+    Find the most recent spectrum_claims_results_*.csv under the given directories.
+    Defaults to experiments/results and results relative to cwd and package root.
+    """
+    if search_dirs is None:
+        base = Path(__file__).resolve().parent.parent
+        search_dirs = [
+            Path("experiments/results"),
+            Path("results"),
+            base / "experiments" / "results",
+        ]
+    for d in search_dirs:
+        if not d.exists():
+            continue
+        files = sorted(
+            d.glob("spectrum_claims_results_*.csv"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        if files:
+            return files[0]
+    return None

--- a/tests/steps/test_advocate.py
+++ b/tests/steps/test_advocate.py
@@ -85,7 +85,7 @@ def test_evaluate_claim(mock_llm: MagicMock, mock_retriever: MagicMock) -> None:
         options=options, 
         evidence_options=evidence_options
     )
-    verdict, reasoning = advocate.evaluate_claim("Test claim")
+    verdict, reasoning, _, _, _ = advocate.evaluate_claim("Test claim")
     
     assert mock_llm.chat.called
     assert verdict == "CORRECT"
@@ -98,7 +98,7 @@ def test_llm_error_handling(mock_llm: MagicMock, mock_retriever: MagicMock) -> N
         retriever=mock_retriever,
         llm=mock_llm,
     )
-    verdict, reasoning = advocate.evaluate_claim("Test claim")
+    verdict, reasoning, _, _, _ = advocate.evaluate_claim("Test claim")
     
     assert verdict == "ERROR_PARSING_RESPONSE"
     assert reasoning == "No reasoning available"
@@ -117,7 +117,7 @@ def test_retry_mechanism(mock_llm: MagicMock, mock_retriever: MagicMock) -> None
         llm=mock_llm,
     )
     
-    verdict, reasoning = advocate.evaluate_claim("Test claim")
+    verdict, reasoning, _, _, _ = advocate.evaluate_claim("Test claim")
     assert verdict == "CORRECT"
     assert mock_llm.chat.call_count == 3
 
@@ -131,7 +131,7 @@ def test_advocate_retry_includes_format_feedback(mock_llm: MagicMock, mock_retri
         MagicMock(message=MagicMock(content=right)),
     ]
     advocate = AdvocateStep(retriever=mock_retriever, llm=mock_llm)
-    verdict, _ = advocate.evaluate_claim("Test claim")
+    verdict, _, _, _, _ = advocate.evaluate_claim("Test claim")
     assert verdict == "CORRECT"
     assert mock_llm.chat.call_count == 2
     messages_second = mock_llm.chat.call_args[0][0]
@@ -155,7 +155,7 @@ def test_advocate_custom_verdict_parser(mock_llm: MagicMock, mock_retriever: Mag
         llm=mock_llm,
         options={"verdict_parser": parse_json_style},
     )
-    verdict, reasoning = advocate.evaluate_claim("Test claim")
+    verdict, reasoning, _, _, _ = advocate.evaluate_claim("Test claim")
     assert verdict == "CORRECT"
     assert "Parsed from JSON-style" in reasoning
     assert mock_llm.chat.call_count == 1 

--- a/tests/strategies/conftest.py
+++ b/tests/strategies/conftest.py
@@ -70,7 +70,7 @@ def mock_advocate_step()-> Generator[Mock, None, None]:
     """Fixture to mock the AdvocateStep class."""
     with patch('factchecker.strategies.advocate_mediator.AdvocateStep', autospec=True) as mock:
         advocate = Mock()
-        advocate.evaluate_claim.return_value = ("SUPPORTS", "Based on strong evidence, this claim is supported")
+        advocate.evaluate_claim.return_value = ("SUPPORTS", "Based on strong evidence, this claim is supported", None, None, None)
         mock.return_value = advocate
         yield mock
 

--- a/tests/strategies/test_advocate_mediator.py
+++ b/tests/strategies/test_advocate_mediator.py
@@ -13,13 +13,13 @@ def test_advocate_evaluation_with_evidence(
     # Configure the dummy advocate (returned by the patched AdvocateStep) to return different values.
     dummy_adv = mock_advocate_step.return_value
     dummy_adv.evaluate_claim.side_effect = [
-        ("SUPPORTS", "High confidence support"),
-        ("PARTIALLY_SUPPORTS", "Medium confidence support"),
-        ("REFUTES", "Low confidence support")
+        ("SUPPORTS", "High confidence support", None, None, None),
+        ("PARTIALLY_SUPPORTS", "Medium confidence support", None, None, None),
+        ("REFUTES", "Low confidence support", None, None, None),
     ]
 
     claim = "Test claim for evidence evaluation"
-    final_verdict, verdicts, reasonings = advocate_mediator_strategy.evaluate_claim(claim)
+    final_verdict, verdicts, reasonings, _, _ = advocate_mediator_strategy.evaluate_claim(claim)
 
     # Verify that evaluate_claim was called three times (one per advocate).
     assert dummy_adv.evaluate_claim.call_count == 3
@@ -39,8 +39,8 @@ def test_mediator_synthesis_logic(
     """Test that mediator properly synthesizes different combinations of verdicts."""
     dummy_adv = mock_advocate_step.return_value
     dummy_adv.evaluate_claim.side_effect = [
-        ("SUPPORTS", "Support reasoning"),
-        ("REFUTES", "Refute reasoning")
+        ("SUPPORTS", "Support reasoning", None, None, None),
+        ("REFUTES", "Refute reasoning", None, None, None),
     ]
 
     dummy_med = mock_mediator_step.return_value
@@ -49,11 +49,11 @@ def test_mediator_synthesis_logic(
     strategy = advocate_mediator_strategy_factory(2)
 
     claim = "Test claim for mediator synthesis"
-    final_verdict, verdicts, reasonings = strategy.evaluate_claim(claim)
+    final_verdict, verdicts, reasonings, _, _ = strategy.evaluate_claim(claim)
 
     expected_verdicts = [
         ("SUPPORTS", "Support reasoning"),
-        ("REFUTES", "Refute reasoning")
+        ("REFUTES", "Refute reasoning"),
     ]
     dummy_med.synthesize_verdicts.assert_called_once_with(expected_verdicts, claim)
     assert final_verdict == "INCONCLUSIVE"
@@ -114,7 +114,7 @@ def test_fail_fast_on_advocate_error(
     advocate1 = Mock()
     advocate1.evaluate_claim.side_effect = Exception("Evidence evaluation failed")
     advocate2 = Mock()
-    advocate2.evaluate_claim.return_value = ("SUPPORTS", "Successful evaluation")
+    advocate2.evaluate_claim.return_value = ("SUPPORTS", "Successful evaluation", None, None, None)
     
     # Set the side effect on the patched AdvocateStep: first call fails, second would succeed.
     mock_advocate_step.side_effect = [advocate1, advocate2]
@@ -182,7 +182,7 @@ def test_real_world_configuration(mock_llama_indexer, mock_llama_retriever, mock
 
     # Test with a realistic climate claim
     claim = "Global temperatures have not risen in the past decade"
-    final_verdict, verdicts, reasonings = strategy.evaluate_claim(claim)
+    final_verdict, verdicts, reasonings, _, _ = strategy.evaluate_claim(claim)
 
     # Verify the configuration was properly passed to the advocate step
     mock_advocate_step.assert_called_with(

--- a/tests/utils/test_climatefeedback_utils.py
+++ b/tests/utils/test_climatefeedback_utils.py
@@ -87,11 +87,11 @@ def test_map_verdict_invalid_level():
 def test_evaluate_climatefeedback_claims_returns_collectors_and_errors():
     """evaluate_climatefeedback_claims returns (collectors, errors); no errors when all succeed."""
     strategy = _make_mock_strategy(
-        [
-            ("correct", ["SUPPORTS"], ["r1"]),
-            ("incorrect", ["REFUTES"], ["r2"]),
-        ]
-    )
+            [
+                ("correct", ["SUPPORTS"], ["r1"], None, None),
+                ("incorrect", ["REFUTES"], ["r2"], None, None),
+            ]
+        )
     claims_df = pd.DataFrame({
         "Claim": ["First claim.", "Second claim."],
         "Climate Feedback": ["correct", "incorrect"],
@@ -109,9 +109,9 @@ def test_evaluate_climatefeedback_claims_tracks_errors_on_failure():
     """When strategy raises on some claims, errors list is populated and collectors only have successes."""
     strategy = _make_mock_strategy(
         [
-            ("correct", ["SUPPORTS"], ["r1"]),
+            ("correct", ["SUPPORTS"], ["r1"], None, None),
             None,  # second call raises
-            ("correct", ["SUPPORTS"], ["r3"]),
+            ("correct", ["SUPPORTS"], ["r3"], None, None),
         ],
         raise_on_none=True,
     )
@@ -132,9 +132,9 @@ def test_evaluate_climatefeedback_claims_claim_indices_only_successes():
     """claim_indices contains only indices of successfully evaluated claims."""
     strategy = _make_mock_strategy(
         [
-            ("correct", ["SUPPORTS"], ["r1"]),
+            ("correct", ["SUPPORTS"], ["r1"], None, None),
             None,  # raise on index 1
-            ("incorrect", ["REFUTES"], ["r3"]),
+            ("incorrect", ["REFUTES"], ["r3"], None, None),
         ],
         raise_on_none=True,
     )


### PR DESCRIPTION
…arisons

- Advocate/mediator steps: evidence classifier, chunk labelling (supports/refutes/NIN), advocate_evidence_display (full/relevant_only), mediator modes (llm/formula), llm_with_advocate_proof, mediator_evidence_relevant_only
- Spectrum experiment: 6-run comparison (ablation, mediator evidence, three-way, advocate/mediator relevant_only), comparison_runs option for subset runs
- Prompts: classified evidence, chunk stats, evidence classifier with reason
- Utils: spectrum_analysis, climatefeedback verdict mapping, normalized metrics
- .gitignore: drafts/, .venv*